### PR TITLE
Register commands via command map rather than vice versa

### DIFF
--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -268,17 +268,20 @@ public class ScriptCommand implements CommandExecutor {
 					aliases.add(lowerAlias);
 			}
 			bukkitCommand.setAliases(activeAliases);
-			bukkitCommand.register(commandMap);
+			commandMap.register("skript", bukkitCommand);
 		}
 	}
 	
 	public void unregister(final SimpleCommandMap commandMap, final Map<String, Command> knownCommands, final @Nullable Set<String> aliases) {
 		synchronized (commandMap) {
 			knownCommands.remove(label);
+			knownCommands.remove("skript:" + label);
 			if (aliases != null)
 				aliases.removeAll(activeAliases);
-			for (final String alias : activeAliases)
+			for (final String alias : activeAliases) {
 				knownCommands.remove(alias);
+				knownCommands.remove("skript:" + alias);
+			}
 			activeAliases = new ArrayList<String>(this.aliases);
 			bukkitCommand.unregister(commandMap);
 			bukkitCommand.setAliases(this.aliases);


### PR DESCRIPTION
This is a minor change to how Skript registers commands for scripts. Instead of registering the command map to the created Bukkit command, the command is registered to Bukkit's command map.

# Rationale

I made this change from @Zbob750's advice after discovering an issue with [Skript commands and command blocks on PaperSpigot](https://github.com/PaperMC/Paper/issues/256). Despite PaperSpigot having since added a workaround, I figured it would be better to fix this for Skript.

# Side-effects

By registering via the command map, all Skript commands and their aliases gain a duplicate with the `skript:` prefix. For example, this Skript command:
```
command /servertime:
    description: Get's the server's IRL time/date
    aliases: /stime, /date
    executable by: players and console
    trigger:
        broadcast "&7*** Current server date/time: &f%now%"
```
Registers the commands `/servertime`, `/stime`, `/date` along with `/skript:servertime`, `/skript:stime`, `/skript:date`. I have added code to clean these up when unregistering a Skript command.

# Testing

## Environment

* PaperSpigot [b712](https://ci.destroystokyo.com/job/PaperSpigot/712/) (before Skript workaround) and [b726](https://ci.destroystokyo.com/job/PaperSpigot/726/)
* Local server with EssentialsX, Multiverse-Core and Vault
* [Self-written collection of Skripts loaded for testing](https://github.com/Gamealition/Survival-Skripts)

## Checklist

* No compilation or runtime exceptions
* No potential null access (checked by eye and annotations)
* Registered commands and aliases work in-game, in-console and in command blocks
* Registered commands and aliases work via `skript:` prefix
* Overridden commands work
* Unregistered commands and aliases (after `/sk reload all`) removed
* Unregistered commands and aliases' prefix alternatives removed
* Overridden commands restored after unregister