### PR TITLE
Cursor item deletion bugfix

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -90,7 +90,7 @@ public class EffPotion extends Effect {
 		if (ts.length == 0)
 			return;
 		if (!apply) {
-			for (LivingEntity en : entities.getAll(e)) {
+			for (LivingEntity en : entities.getArray(e)) {
 				for (final PotionEffectType t : ts)
 					en.removePotionEffect(t);
 			}

--- a/src/main/java/ch/njol/skript/effects/EffPotion.java
+++ b/src/main/java/ch/njol/skript/effects/EffPotion.java
@@ -90,7 +90,7 @@ public class EffPotion extends Effect {
 		if (ts.length == 0)
 			return;
 		if (!apply) {
-			for (final LivingEntity en : entities.getArray(e)) {
+			for (LivingEntity en : entities.getAll(e)) {
 				for (final PotionEffectType t : ts)
 					en.removePotionEffect(t);
 			}


### PR DESCRIPTION
This fixes a bug for players in creative mode having their cursor item dissapear when a potion effect was being removed.