### PR TITLE
Add `any mutton` and `any rabbit meat` aliases

### DIFF
--- a/src/main/resources/aliases-english.sk
+++ b/src/main/resources/aliases-english.sk
@@ -1362,6 +1362,7 @@ default aliases:
 	hopper(_| )minecart¦s = 408
 	prismarine(_| )shard¦s = 409:0
 	prismarine(_| )crystal¦s = 410
+	[<any>](_| )rabbit meat = 411, 412
 	raw(_| )rabbit = 411
 	cooked(_| )rabbit = 412
 	rabbit(_| )stew = 413
@@ -1374,6 +1375,7 @@ default aliases:
 	lead¦s = 420
 	name(_| )tag¦s = 421
 	command(_| )block(_| )minecart¦¦s¦ = 422
+	[<any>](_| )mutton = 423, 424
 	raw(_| )mutton = 423
 	cooked(_| )mutton = 424
 	any(_| )banner = 176:0-15, 177:0-15, 425:0-15


### PR DESCRIPTION
Allows Skripts to pick both kinds of rabbit and mutton meat (raw and cooked). Consistent with `any beef` and `any chicken` aliases.

# Testing

* Local Spigot 1.11 server
  * `CraftBukkit version git-Spigot-f950f8e-9dee108 (MC: 1.11) (Implementing API version 1.11-R0.1-SNAPSHOT)`
  * Plugins (1): Skript dev22e
  * Using default Skript config and aliases
  * No Skript addons

Tested with Skript:

```
on right click:
	if held item is any mutton or any rabbit meat:
		message "*** Held: %held item%"
```