### PR TITLE
2 new expressions and fix for EffReplace and EffOpenInventory

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
+++ b/src/main/java/ch/njol/skript/effects/EffOpenInventory.java
@@ -99,7 +99,11 @@ public class EffOpenInventory extends Effect {
 			if (i == null)
 				return;
 			for (final Player p : players.getArray(e)) {
-				p.openInventory(i);
+				try {
+					p.openInventory(i);
+				} catch (IllegalArgumentException ex){
+					Skript.error("You can't open a " +i.getType().name().toLowerCase().replaceAll("_", "") + " inventory to a player.");
+				}
 			}
 		} else {
 			for (final Player p : players.getArray(e)) {

--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -21,7 +21,13 @@
 
 package ch.njol.skript.effects;
 
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -42,49 +48,64 @@ import ch.njol.util.StringUtils;
  * @author Peter Güttinger
  */
 @Name("Replace")
-@Description("Replaces all occurrences of a given text with another text. Please note that you can only change variables and a few expressions, e.g. a <a href='../expressions/#ExprMessage'>message</a> or a line of a sign.")
+@Description({"Replaces all occurrences of a given text with another text. Please note that you can only change variables and a few expressions, e.g. a <a href='../expressions/#ExprMessage'>message</a> or a line of a sign.",
+		"Starting with 2.2-dev23a, you can replace items in a inventory too."})
 @Examples({"replace \"<item>\" in {textvar} with \"%item%\"",
 		"replace every \"&\" with \"§\" in line 1",
 		"# The following acts as a simple chat censor, but it will e.g. censor mass, hassle, assassin, etc. as well:",
 		"on chat:",
-		"	replace all \"fuck\", \"bitch\" and \"ass\" with \"****\" in the message"})
-@Since("2.0")
-// TODO add 'replace all <items> in <inventories> with <item>'
+		"	replace all \"fuck\", \"bitch\" and \"ass\" with \"****\" in the message",
+		" ",
+		"replace all stone and dirt in player's inventory and player's top inventory with diamond"})
+@Since("2.0, 2.2-dev23a (replace in muliple strings and replace items in inventory)")
 public class EffReplace extends Effect {
 	static {
 		Skript.registerEffect(EffReplace.class,
-				"replace (all|every|) %strings% in %string% with %strings%",
-				"replace (all|every|) %strings% with %string% in %strings%");
+				"replace (all|every|) %strings% in %strings% with %string%",
+				"replace (all|every|) %strings% with %string% in %strings%",
+				"replace (all|every|) %itemstacks% in %inventories% with %itemstack%",
+				"replace (all|every|) %itemstacks% with %itemstack% in %inventories%");
 	}
 	
 	@SuppressWarnings("null")
-	private Expression<String> haystack, needles, replacement;
-	
-	@SuppressWarnings({"unchecked", "null"})
+	private Expression<?> haystack, needles, replacement;
+	private boolean replaceString = true;
+	@SuppressWarnings({"null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		haystack = (Expression<String>) exprs[1 + matchedPattern];
-		if (!ChangerUtils.acceptsChange(haystack, ChangeMode.SET, String.class)) {
+		haystack =  exprs[1 + matchedPattern % 2];
+		replaceString = matchedPattern < 2;
+		if (replaceString && !ChangerUtils.acceptsChange(haystack, ChangeMode.SET, String.class)) {
 			Skript.error(haystack + " cannot be changed and can thus not have parts replaced.");
 			return false;
 		}
-		needles = (Expression<String>) exprs[0];
-		replacement = (Expression<String>) exprs[2 - matchedPattern];
+		needles = exprs[0];
+		replacement = exprs[2 - matchedPattern % 2];
 		return true;
 	}
 	
+	@SuppressWarnings("null")
 	@Override
 	protected void execute(final Event e) {
-		String h = haystack.getSingle(e);
-		final String[] ns = needles.getAll(e);
-		final String r = replacement.getSingle(e);
-		if (h == null || ns.length == 0 || r == null)
+		Object[] haystack = this.haystack.getAll(e);
+		Object[] needles = this.needles.getAll(e);
+		Object replacement = this.replacement.getSingle(e);
+		if (replacement == null || haystack == null || haystack.length == 0 || needles == null || needles.length == 0)
 			return;
-		for (final String n : ns) {
-			assert n != null;
-			h = StringUtils.replace(h, n, r, SkriptConfig.caseSensitive.value());
+		if (replaceString) {
+			for (int x = 0; x < haystack.length; x++)
+				for (final Object n : needles) {
+					assert n != null;
+					haystack[x] = StringUtils.replace((String)haystack[x], (String)n, (String)replacement, SkriptConfig.caseSensitive.value());
+				}
+			this.haystack.change(e, haystack, ChangeMode.SET);
+		} else {
+			for (Inventory inv : (Inventory[])haystack)
+				for (ItemStack item : (ItemStack[]) needles)
+					for (Integer slot : inv.all(item).keySet()){
+						inv.setItem(slot.intValue(), (ItemStack)replacement);
+					}
 		}
-		haystack.change(e, new String[] {h}, ChangeMode.SET);
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -1,0 +1,105 @@
+/*
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 
+ * Copyright 2011-2016 Peter Güttinger and contributors
+ * 
+ */
+
+package ch.njol.skript.expressions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.event.Event;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.InventorySlot;
+import ch.njol.skript.util.Slot;
+import ch.njol.util.Kleenean;
+
+/**
+ *
+ */
+@Name("Inventory Slot")
+@Description({"Represents a slot in a inventory. It can be used to change the item in a inventory too."})
+@Examples({"if slot 0 of player is air:",
+	"\tset slot 0 of player to 2 stones",
+	"\tremove 1 stone from slot 0 of player",
+	"\tadd 2 stones to slot 0 of player",
+	"\tclear slot 1 of player"})
+@Since("2.2-dev23a")
+public class ExprInventorySlot extends SimpleExpression<Slot>{
+	
+	static {
+		Skript.registerExpression(ExprInventorySlot.class, Slot.class, ExpressionType.COMBINED, "[the] slot %number% of %inventory%","%inventory%'[s] slot %number%");
+	}
+
+	@SuppressWarnings("null")
+	private Expression<Number> slots;
+	@SuppressWarnings("null")
+	private Expression<Inventory> invis;
+	
+	@SuppressWarnings({"null", "unchecked"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		if (matchedPattern == 0){
+			 slots = (Expression<Number>) exprs[0];
+			 invis = (Expression<Inventory>) exprs[1];
+		} else {
+			 slots = (Expression<Number>) exprs[1];
+			 invis = (Expression<Inventory>) exprs[0];			
+		}
+		return true;
+	}
+
+	@Override
+	@Nullable
+	protected Slot[] get(Event e) {
+		Number slot = slots.getSingle(e);
+		Inventory inv = invis.getSingle(e);
+		if (inv != null && slot != null && slot.intValue() >= 0 && slot.intValue() < inv.getSize()){
+			return new Slot[]{new InventorySlot(inv, slot.intValue())};
+		}
+		return null;
+	}
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public Class<? extends Slot> getReturnType() {
+		return Slot.class;
+	}
+	
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "slot " + slots.toString(e, debug) + " of " + invis.toString(e, debug);
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprOpenInventory.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprOpenInventory.java
@@ -1,0 +1,60 @@
+/*
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 
+ * Copyright 2011-2016 Peter Güttinger and contributors
+ * 
+ */
+
+package ch.njol.skript.expressions;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+
+@Name("Open Inventory")
+@Description({"Return the open inventory of a player.",
+	"If no inventory is open, it returns the own player's crafting inventory."})
+@Examples({"set slot 1 of open inventory of player to diamond sword"})
+@Since("2.2-dev23a")
+public class ExprOpenInventory extends SimplePropertyExpression<Player, Inventory>{
+	static {
+		register(ExprOpenInventory.class, Inventory.class, "(current|open|top) inventory", "player");
+	}
+
+	@Override
+	public Class<? extends Inventory> getReturnType() {
+		return Inventory.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "open inventory";
+	}
+
+	@Override
+	@Nullable
+	public Inventory convert(Player p) {
+		return p.getOpenInventory() != null ? p.getOpenInventory().getTopInventory() : null;
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprUUID.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprUUID.java
@@ -23,6 +23,7 @@ package ch.njol.skript.expressions;
 
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -37,9 +38,9 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
  * @author Peter Güttinger
  */
 @Name("UUID")
-@Description({"The UUID of a player or world.",
+@Description({"The UUID of a player, entity or world.",
 		"In the future there will be an option to use a player's UUID instead of the name in variable names (i.e. when %player% is used), but for now this can be used.",
-		"<em>Please note that this expression does not work for offline players!</em>"})
+		"<em>Please note that this expression does not work for offline players if you are under 1.8!</em>"}) 
 // TODO [UUID] update documentation after release. Add note about requiring Bukkit 1.7.(9/10)?
 @Examples({"# prevents people from joining the server if they use the name of a player",
 		"# who has played on this server at least once since this script has been added",
@@ -49,11 +50,11 @@ import ch.njol.skript.expressions.base.SimplePropertyExpression;
 		"		kick player due to \"Someone with your name has played on this server before\"",
 		"	else:",
 		"		set {uuids.%name of player%} to UUID of player"})
-@Since("2.1.2, 2.2 (offline players' UUIDs)")
+@Since("2.1.2, 2.2 (offline players' UUIDs), 2.2-dev23a (entitiy's UUIDs)")
 public class ExprUUID extends SimplePropertyExpression<Object, String> {
 	private final static boolean offlineUUIDSupported = Skript.methodExists(OfflinePlayer.class, "getUniqueId");
 	static {
-		register(ExprUUID.class, String.class, "UUID", (offlineUUIDSupported ? "offlineplayers" : "players") + "/worlds");
+		register(ExprUUID.class, String.class, "UUID", "entities/" + (offlineUUIDSupported ? "offlineplayers" : "players") + "/worlds");
 	}
 	
 	@Override
@@ -72,6 +73,8 @@ public class ExprUUID extends SimplePropertyExpression<Object, String> {
 				}
 			} else
 				return ((Player) o).getUniqueId().toString();
+		} else if (o instanceof Entity) {
+			return ((Entity)o).getUniqueId().toString();
 		} else if (o instanceof World) {
 			return ((World) o).getUID().toString();
 		}


### PR DESCRIPTION
* Fixed previous commit on `EffReplace` that was trowing a `SkriptAPIException` for using `getSingle()` wrongly, [Stacktrace here](https://hastebin.com/ripaseguhu.bash). Also added an option to replace items in inventory as it was in TODO.
```
replace (all|every|) %itemstacks% in %inventories% with %itemstack%
replace (all|every|) %itemstacks% with %itemstack% in %inventories%
```

* Fixed `EffOpenInventory` surrounding with try/catch as Bukkit throw `IllegalArgumentException` when a player can't open a specific inventory.

* Added support for `entities` in `ExprUUID`.

* Added new expressions to get the slot of a inventory and to get a top inventory.
```
[the] slot %number% of %inventory%
%inventory%'[s] slot %number%

[the] (current|open|top) inventory of %player%
%player%'[s] (current|open|top) inventory
```
The `slot` expression is from #359 

This time I tested and compiled everything to make sure it is working. 😂 
I also was using `2.2-dev23a` as it will be the next release, in case it won't, it will be needed to change:
[here](https://github.com/bensku/Skript/pull/373/commits/7106ecb2d1a39f133a9da32220dfa525d3cc9d93#diff-191a8ebc847551abb18e063d93012472R60), [here](https://github.com/bensku/Skript/pull/373/commits/7106ecb2d1a39f133a9da32220dfa525d3cc9d93#diff-191a8ebc847551abb18e063d93012472R52), [here](https://github.com/bensku/Skript/pull/373/commits/7106ecb2d1a39f133a9da32220dfa525d3cc9d93#diff-13968ed837157b6790276075352523a1R55), [here](https://github.com/bensku/Skript/pull/373/commits/7106ecb2d1a39f133a9da32220dfa525d3cc9d93#diff-73fc07fee8317ca289ae777317547ff6R38) and [here](https://github.com/bensku/Skript/pull/373/commits/7106ecb2d1a39f133a9da32220dfa525d3cc9d93#diff-f5a0295a64e5286153e4f899b084148fR53).

A script to test everything:
```
command /uuidtest:
	trigger:
		send "Player's uuid:" and " - %uuid of player%"
		send "World's uuid:" and " - %uuid of world%"
		send "Entity's uuid:" and " - %uuid of targeted entity%"
		
command /slottest:
	trigger:
		send "%slot 0 of player%"
		send "%slot 0 of player's inventory%"
		set slot 0 of player to 2 stones
		wait 1 second
		remove 1 stone from slot 0 of player
		wait 1 second
		add 2 stones to slot 0 of player
		wait 1 second
		clear slot 0 of player
		
command /replacetest:
	trigger:
		set {_values::*} to "abca" and "acda"
		send "%{_values::*}%"
		replace "b", "c" and "d" with "A" in {_values::*}
		send "%{_values::*}%"
		set slot 1 of top inventory of player to stone
		replace all stone and dirt with diamond in player's inventory and player's top inventory
```

Also, a question. Should I make pull request one by one or it's ok like that?
