### PR TITLE
Boat support, multiple passengers, "last dropped item" expression, new event values and fixes.

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/PassengerUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PassengerUtils.java
@@ -62,7 +62,7 @@ public abstract class PassengerUtils {
 			try {
 				return new Entity[]{(Entity)getPassenger.invoke(e)};		
 			} catch (final Exception ex) { //I don't think it can happen, but just in case.
-				Skript.exception(ex, "A error occured while trying to get a passenger in version lower than 1.11.");
+				Skript.exception(ex, "A error occured while trying to get a passenger in version lower than 1.11.2.");
 			} 
 		}
 		return null;
@@ -82,7 +82,7 @@ public abstract class PassengerUtils {
 				vehicle.eject();
 				setPassenger.invoke(vehicle, passenger);
 			} catch (final Exception ex) { 
-				Skript.exception(ex, "A error occured while trying to set a passenger in version lower than 1.11.");
+				Skript.exception(ex, "A error occured while trying to set a passenger in version lower than 1.11.2.");
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/bukkitutil/PassengerUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/PassengerUtils.java
@@ -1,0 +1,110 @@
+/*
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 
+ * Copyright 2011-2016 Peter Güttinger and contributors
+ * 
+ */
+
+package ch.njol.skript.bukkitutil;
+
+import java.lang.reflect.Method;
+
+import org.bukkit.entity.Entity;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.expressions.ExprPassenger;
+import ch.njol.skript.lang.ExpressionType;
+
+/**
+ * @author Peter Güttinger and contributors
+ */
+@SuppressWarnings("null")
+public abstract class PassengerUtils {
+	
+	private PassengerUtils() {}
+	
+	//Using reflection methods cause it will be removed soon in 1.12
+	private static Method getPassenger = null;
+	private static Method setPassenger = null;
+	
+	
+	static {
+		if (!Skript.methodExists(Entity.class, "getPassengers")) {
+			try {
+				getPassenger = Entity.class.getDeclaredMethod("getPassenger");
+				setPassenger = Entity.class.getDeclaredMethod("setPassenger", Entity.class);
+			} catch (final NoSuchMethodException ex) {
+				Skript.outdatedError(ex);
+			} catch (final Exception ex) {
+				Skript.exception(ex);
+			} 
+		}
+	}
+
+	public static Entity[] getPassenger(Entity e) {
+		if (hasMultiplePassenger()) {
+			return e.getPassengers().toArray(new Entity[0]);
+		} else {
+			try {
+				return new Entity[]{(Entity)getPassenger.invoke(e)};		
+			} catch (final Exception ex) { //I don't think it can happen, but just in case.
+				Skript.exception(ex, "A error occured while trying to get a passenger in version lower than 1.11.");
+			} 
+		}
+		return null;
+	}
+	/**
+	 * Add the passenger to the vehicle
+	 * @param vehicle - The entity vehicle
+	 * @param passenger - The entity passenger
+	 */
+	public static void addPassenger(Entity vehicle, Entity passenger) {
+		if (vehicle == null || passenger == null)
+			return;
+		if (hasMultiplePassenger()) {
+			vehicle.addPassenger(passenger);
+		} else {
+			try {
+				vehicle.eject();
+				setPassenger.invoke(vehicle, passenger);
+			} catch (final Exception ex) { 
+				Skript.exception(ex, "A error occured while trying to set a passenger in version lower than 1.11.");
+			}
+		}
+	}
+	/**
+	 * Remove the passenger from the vehicle.
+	 * @param vehicle - The entity vehicle
+	 * @param passenger - The entity passenger
+	 */
+	public static void removePassenger(Entity vehicle, Entity passenger){
+		if (vehicle == null || passenger == null)
+			return;
+		if (hasMultiplePassenger()){
+			vehicle.removePassenger(passenger);
+		} else {
+			vehicle.eject();
+		}
+	}
+	/**
+	 * @return True if it supports multiple passengers
+	 */
+	public static boolean hasMultiplePassenger(){
+		return setPassenger == null;
+	}
+	
+}

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -26,6 +26,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -106,6 +107,7 @@ import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.BlockStateBlock;
 import ch.njol.skript.util.BlockUtils;
 import ch.njol.skript.util.DelayedChangeBlock;
+import ch.njol.skript.util.Direction;
 import ch.njol.skript.util.Getter;
 import ch.njol.skript.util.InventorySlot;
 import ch.njol.skript.util.Slot;
@@ -203,6 +205,14 @@ public final class BukkitEventValues {
 				return new BlockStateBlock(e.getBlockReplacedState());
 			}
 		}, -1);
+		EventValues.registerEventValue(BlockPlaceEvent.class, Direction.class, new Getter<Direction, BlockPlaceEvent>() {
+			@Override
+			@Nullable
+			public Direction get(final BlockPlaceEvent e) {
+				BlockFace bf = e.getBlockPlaced().getFace(e.getBlockAgainst());
+				return new Direction(new double[]{bf.getModX(), bf.getModY(), bf.getModZ()});
+			}
+		}, 0);
 		// BlockFadeEvent
 		EventValues.registerEventValue(BlockFadeEvent.class, Block.class, new Getter<Block, BlockFadeEvent>() {
 			@Override
@@ -595,6 +605,15 @@ public final class BukkitEventValues {
 			@Nullable
 			public ItemStack get(final PlayerInteractEvent e) {
 				return e.getItem();
+			}
+		}, 0);
+		EventValues.registerEventValue(PlayerInteractEvent.class, Direction.class, new Getter<Direction, PlayerInteractEvent>() {
+			@Override
+			@Nullable
+			public Direction get(final PlayerInteractEvent e) {
+				if (e.getBlockFace() != null)
+					return new Direction(new double[]{e.getBlockFace().getModX(), e.getBlockFace().getModY(), e.getBlockFace().getModZ()});
+				return Direction.ZERO; // Same as 'BlockFace.SELF' or literal 'at'
 			}
 		}, 0);
 		// PlayerShearEntityEvent

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -58,6 +58,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityEvent;
 import org.bukkit.event.entity.EntityTameEvent;
+import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.hanging.HangingEvent;
@@ -435,6 +436,14 @@ public final class BukkitEventValues {
 				}
 			}, 0);
 		}
+		// ItemSpawnEvent
+		EventValues.registerEventValue(ItemSpawnEvent.class, ItemStack.class, new Getter<ItemStack, ItemSpawnEvent>() {
+			@Override
+			@Nullable
+			public ItemStack get(final ItemSpawnEvent e) {
+				return e.getEntity().getItemStack();
+			}
+		}, 0);
 		
 		// --- PlayerEvents ---
 		EventValues.registerEventValue(PlayerEvent.class, Player.class, new Getter<Player, PlayerEvent>() {

--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -209,8 +209,11 @@ public final class BukkitEventValues {
 			@Override
 			@Nullable
 			public Direction get(final BlockPlaceEvent e) {
-				BlockFace bf = e.getBlockPlaced().getFace(e.getBlockAgainst());
-				return new Direction(new double[]{bf.getModX(), bf.getModY(), bf.getModZ()});
+				if (e.getBlock() != null) {
+					BlockFace bf = e.getBlockPlaced().getFace(e.getBlockAgainst());
+					return new Direction(new double[]{bf.getModX(), bf.getModY(), bf.getModZ()});
+				}
+				return Direction.ZERO;
 			}
 		}, 0);
 		// BlockFadeEvent

--- a/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
+++ b/src/main/java/ch/njol/skript/classes/data/DefaultComparators.java
@@ -28,6 +28,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Chicken;
@@ -59,6 +60,7 @@ import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Comparator;
+import ch.njol.skript.entity.BoatData;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.registrations.Comparators;
 import ch.njol.skript.util.Date;
@@ -235,6 +237,8 @@ public class DefaultComparators {
 				Skript.exception(e, "Cannot initialize material support for minecarts");
 			}
 		}
+		if (Skript.classExists("org.bukkit.entity.ArmorStand"))
+			entityMaterials.put(ArmorStand.class, Material.ARMOR_STAND);
 	}
 	public final static Comparator<EntityData, ItemType> entityItemComparator = new Comparator<EntityData, ItemType>() {
 		@Override
@@ -245,6 +249,8 @@ public class DefaultComparators {
 				return Relation.get(i.isOfType(Material.POTION.getId(), PotionEffectUtils.guessData((ThrownPotion) e)));
 			if (Skript.classExists("org.bukkit.entity.WitherSkull") && e instanceof WitherSkull)
 				return Relation.get(i.isOfType(Material.SKULL_ITEM.getId(), (short) 1));
+			if (e instanceof BoatData)
+				return Relation.get(((BoatData)e).isOfItemType(i));
 			if (entityMaterials.containsKey(e.getType()))
 				return Relation.get(i.isOfType(entityMaterials.get(e.getType()).getId(), (short) 0));
 			for (final Entry<Class<? extends Entity>, Material> m : entityMaterials.entrySet()) {

--- a/src/main/java/ch/njol/skript/effects/EffDrop.java
+++ b/src/main/java/ch/njol/skript/effects/EffDrop.java
@@ -21,6 +21,7 @@ package ch.njol.skript.effects;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Item;
 import org.bukkit.event.Event;
@@ -56,6 +57,9 @@ public class EffDrop extends Effect {
 		Skript.registerEffect(EffDrop.class, "drop %itemtypes/experience% [%directions% %locations%]",
 				"drop %itemtypes/experience% [%directions% %locations%] without velocity");
 	}
+	
+	@Nullable
+	public static Entity lastSpawned = null;
 	
 	@SuppressWarnings("null")
 	private Expression<?> drops;
@@ -93,15 +97,17 @@ public class EffDrop extends Effect {
 				if (o instanceof Experience) {
 					final ExperienceOrb orb = l.getWorld().spawn(l, ExperienceOrb.class);
 					orb.setExperience(((Experience) o).getXP());
+					EffSpawn.lastSpawned = orb;
 				} else {
 					for (final ItemStack is : ((ItemType) o).getItem().getAll()) {
 						if (is.getType() != Material.AIR) {
 							if (useVelocity) {
-								l.getWorld().dropItemNaturally(itemDropLoc, is);
+								lastSpawned = l.getWorld().dropItemNaturally(itemDropLoc, is);
 							} else {
 								final Item item = l.getWorld().dropItem(l, is);
 								item.teleport(l);
 								item.setVelocity(new Vector(0, 0, 0));
+								lastSpawned = item;
 							}
 						}
 					}

--- a/src/main/java/ch/njol/skript/entity/BoatData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatData.java
@@ -51,7 +51,6 @@ public class BoatData extends EntityData<Boat> {
 	}
 	
 	private BoatData(int type){
-		Skript.info("new BoatData(" + type + ");");
 		matchedPattern = type;
 	}
 	
@@ -78,7 +77,6 @@ public class BoatData extends EntityData<Boat> {
 
 	@Override
 	protected boolean match(Boat entity) {
-		Skript.info("Match: " + matchedPattern + " - " + entity.getWoodType().ordinal());
 		return matchedPattern <= 1 || entity.getWoodType().ordinal() == matchedPattern - 2;
 	}
 
@@ -115,7 +113,6 @@ public class BoatData extends EntityData<Boat> {
 	public boolean isOfItemType(ItemType i){
 		if (i.getRandom() == null)
 			return false;
-		Skript.info("isOfItemType: " + i.getRandom() + " - " + matchedPattern);
 		int ordinal = -1;
 		switch (i.getRandom().getType()){
 			case BOAT: ordinal = 0 ; break; //It is to make 'boat' and 'any boat' works as supertype when comparing.

--- a/src/main/java/ch/njol/skript/entity/BoatData.java
+++ b/src/main/java/ch/njol/skript/entity/BoatData.java
@@ -1,0 +1,133 @@
+/*
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 
+ * Copyright 2011-2016 Peter Güttinger and contributors
+ * 
+ */
+
+package ch.njol.skript.entity;
+
+import java.util.Random;
+
+import org.bukkit.Material;
+import org.bukkit.TreeSpecies;
+import org.bukkit.entity.Boat;
+import org.eclipse.jdt.annotation.Nullable;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+
+public class BoatData extends EntityData<Boat> {
+	static {
+		// It will only register for 1.10+,
+		// See SimpleEntityData if 1.9 or lower.
+		if (Skript.methodExists(Boat.class, "getWoodType")) { //The 'boat' is the same of 'oak boat', 'any boat' works as supertype and it can spawn random boat.
+			register(BoatData.class, "boat", Boat.class, 0, "boat", "any boat", "oak boat", "spruce boat", "birch boat", "jungle boat", "acacia boat", "dark oak boat");
+		}
+	}
+	
+	public BoatData(){
+		this(0);
+	}
+	
+	public BoatData(@Nullable TreeSpecies type){
+		this(type != null ? type.ordinal() + 2 : 1);
+	}
+	
+	private BoatData(int type){
+		Skript.info("new BoatData(" + type + ");");
+		matchedPattern = type;
+	}
+	
+	@Override
+	protected boolean init(Literal<?>[] exprs, int matchedPattern, ParseResult parseResult) {
+		
+		return true;
+	}
+
+	@Override
+	protected boolean init(@Nullable Class<? extends Boat> c, @Nullable Boat e) {
+		if (e != null)
+			matchedPattern = 2 + e.getWoodType().ordinal();
+		return true;
+	}
+
+	@Override
+	public void set(Boat entity) {
+		if (matchedPattern == 1) // If the type is 'any boat'.
+			matchedPattern += new Random().nextInt(TreeSpecies.values().length); // It will spawn a random boat type in case is 'any boat'.
+		if (matchedPattern > 1) // 0 and 1 are excluded
+			entity.setWoodType(TreeSpecies.values()[matchedPattern - 2]); // Removes 2 to fix the index.
+	}
+
+	@Override
+	protected boolean match(Boat entity) {
+		Skript.info("Match: " + matchedPattern + " - " + entity.getWoodType().ordinal());
+		return matchedPattern <= 1 || entity.getWoodType().ordinal() == matchedPattern - 2;
+	}
+
+	@Override
+	public Class<? extends Boat> getType() {
+		return Boat.class;
+	}
+
+	@Override
+	public EntityData getSuperType() {
+		return new BoatData(matchedPattern);
+	}
+
+	@Override
+	protected int hashCode_i() {
+		return matchedPattern <= 1 ? 0 : matchedPattern;
+	}
+
+	@Override
+	protected boolean equals_i(EntityData<?> obj) {
+		if (obj instanceof BoatData)
+			return matchedPattern == ((BoatData)obj).matchedPattern;
+		return false;
+	}
+
+	@Override
+	public boolean isSupertypeOf(EntityData<?> e) {
+		if (e instanceof BoatData)
+			return matchedPattern <= 1 || matchedPattern == ((BoatData)e).matchedPattern;
+		return false;
+	}
+	
+	@SuppressWarnings("null")
+	public boolean isOfItemType(ItemType i){
+		if (i.getRandom() == null)
+			return false;
+		Skript.info("isOfItemType: " + i.getRandom() + " - " + matchedPattern);
+		int ordinal = -1;
+		switch (i.getRandom().getType()){
+			case BOAT: ordinal = 0 ; break; //It is to make 'boat' and 'any boat' works as supertype when comparing.
+			case BOAT_SPRUCE: ordinal = TreeSpecies.REDWOOD.ordinal(); break;
+			case BOAT_BIRCH: ordinal = TreeSpecies.BIRCH.ordinal(); break;
+			case BOAT_JUNGLE: ordinal = TreeSpecies.JUNGLE.ordinal(); break;
+			case BOAT_ACACIA: ordinal = TreeSpecies.ACACIA.ordinal(); break;
+			case BOAT_DARK_OAK: ordinal = TreeSpecies.DARK_OAK.ordinal(); break;
+				//$CASES-OMITTED$
+			default: return false;
+		}
+		return hashCode_i() == ordinal + 2 || (matchedPattern + ordinal == 2) || ordinal == 0;
+		
+	}
+}

--- a/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
+++ b/src/main/java/ch/njol/skript/entity/SimpleEntityData.java
@@ -143,7 +143,8 @@ public class SimpleEntityData extends EntityData<Entity> {
 	private final static List<SimpleEntityDataInfo> types = new ArrayList<>();
 	static {
 		types.add(new SimpleEntityDataInfo("arrow", Arrow.class));
-		types.add(new SimpleEntityDataInfo("boat", Boat.class));
+		if (!Skript.methodExists(Boat.class, "getWoodType")) // Only for 1.9 and lower. See BoatData instead
+			types.add(new SimpleEntityDataInfo("boat", Boat.class));
 		types.add(new SimpleEntityDataInfo("blaze", Blaze.class));
 		types.add(new SimpleEntityDataInfo("chicken", Chicken.class));
 		types.add(new SimpleEntityDataInfo("mooshroom", MushroomCow.class));

--- a/src/main/java/ch/njol/skript/events/EvtItem.java
+++ b/src/main/java/ch/njol/skript/events/EvtItem.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.aliases.ItemType;
+import ch.njol.skript.effects.EffSpawn;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -104,6 +105,8 @@ public class EvtItem extends SkriptEvent {
 	@SuppressWarnings("null")
 	@Override
 	public boolean check(final Event e) {
+		if (e instanceof ItemSpawnEvent) // To make 'last dropped item' possible.
+			EffSpawn.lastSpawned = ((ItemSpawnEvent) e).getEntity();
 		if (types == null)
 			return true;
 		final ItemStack is;

--- a/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
@@ -36,7 +36,6 @@ import ch.njol.skript.effects.EffDrop;
 import ch.njol.skript.effects.EffShoot;
 import ch.njol.skript.effects.EffSpawn;
 import ch.njol.skript.entity.EntityData;
-import ch.njol.skript.entity.XpOrbData;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;

--- a/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprLastSpawnedEntity.java
@@ -22,6 +22,8 @@ package ch.njol.skript.expressions;
 import java.lang.reflect.Array;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.entity.Item;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -30,9 +32,11 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
+import ch.njol.skript.effects.EffDrop;
 import ch.njol.skript.effects.EffShoot;
 import ch.njol.skript.effects.EffSpawn;
 import ch.njol.skript.entity.EntityData;
+import ch.njol.skript.entity.XpOrbData;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
@@ -44,35 +48,40 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 @Name("Last Spawned Entity")
-@Description("Holds the entity that was spawned most recently with the <a href='../effects/#EffSpawn'>spawn effect</a>, or shot with the <a href='../effects/#EffShoot'>shoot effect</a>. " +
+@Description("Holds the entity that was spawned most recently with the <a href='../effects/#EffSpawn'>spawn effect</a>, drop with the <a href='../effects/#EffDrop'>drop effect</a> or shot with the <a href='../effects/#EffShoot'>shoot effect</a>. " +
 		"Please note that even though you can spawn multiple mobs simultaneously (e.g. with 'spawn 5 creepers'), only the last spawned mob is saved and can be used. " +
-		"If you spawn an entity and shoot a projectile you can however access both.")
+		"If you spawn an entity, shoot a projectile and drop a item you can however access all them together.")
 @Examples({"spawn a priest",
 		"set {%spawned priest%.healer} to true",
 		"shoot an arrow from the last spawned entity",
-		"ignite the shot projectile"})
-@Since("1.3 (spawned entity), 2.0 (shot entity)")
+		"ignite the shot projectile",
+		"drop a diamond sword",
+		"push last dropped item upwards"})
+@Since("1.3 (spawned entity), 2.0 (shot entity), 2.2-dev26 (dropped item)")
 public class ExprLastSpawnedEntity extends SimpleExpression<Entity> {
 	static {
-		Skript.registerExpression(ExprLastSpawnedEntity.class, Entity.class, ExpressionType.SIMPLE, "[the] [last[ly]] (0¦spawned|1¦shot) %*entitydata%");
+		Skript.registerExpression(ExprLastSpawnedEntity.class, Entity.class, ExpressionType.SIMPLE, "[the] [last[ly]] (0¦spawned|1¦shot) %*entitydata%", "[the] [last[ly]] dropped (2¦item)");
 	}
 	
-	boolean spawned;
+	int from;
 	@SuppressWarnings("null")
 	private EntityData<?> type;
 	
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parseResult) {
-		type = ((Literal<EntityData<?>>) exprs[0]).getSingle();
-		spawned = parseResult.mark == 0;
+		if (parseResult.mark == 2) // It's just to make an extra expression for item only
+			type = EntityData.fromClass(Item.class);
+		else 
+			type = ((Literal<EntityData<?>>) exprs[0]).getSingle();
+		from = parseResult.mark;
 		return true;
 	}
 	
 	@Override
 	@Nullable
 	protected Entity[] get(final Event e) {
-		final Entity en = spawned ? EffSpawn.lastSpawned : EffShoot.lastSpawned;
+		final Entity en = from == 0 ? EffSpawn.lastSpawned :  from == 1 ? EffShoot.lastSpawned : EffDrop.lastSpawned;
 		if (en == null)
 			return null;
 		if (!type.isInstance(en))
@@ -94,7 +103,7 @@ public class ExprLastSpawnedEntity extends SimpleExpression<Entity> {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return "the last " + (spawned ? "spawned" : "shot") + " " + type;
+		return "the last " + (from == 1 ? "spawned" : from == 1 ? "shot" : "dropped") + " " + type;
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
@@ -53,18 +53,18 @@ import ch.njol.util.coll.CollectionUtils;
 @Name("Passenger")
 @Description({"The passenger of a vehicle, or the rider of a mob.",
 		"See also: <a href='#ExprVehicle'>vehicle</a>",
-		"For 1.10 and above, it returns a list of passengers and you can use all changers in it."})
-@Examples({"#for 1.9",
+		"For 1.11.2 and above, it returns a list of passengers and you can use all changers in it."})
+@Examples({"#for 1.11 and lower",
 		"passenger of the minecart is a creeper or a cow",
 		"the saddled pig's passenger is a player",
-		"#for 1.10 +",
+		"#for 1.11.2+",
 		"passengers of the minecart contains a creeper or a cow",
 		"the boat's passenger contains a pig",
 		"add a cow and a zombie to passengers of last spawned boat",
 		"set passengers of player's vehicle to a pig and a horse",
 		"remove all pigs from player's vehicle",
 		"clear passengers of boat"})
-@Since("2.0, 2.2-dev26 (Multiple passengers for 1.10+)")
+@Since("2.0, 2.2-dev26 (Multiple passengers for 1.11.2+)")
 public class ExprPassenger extends SimpleExpression<Entity> { // REMIND create 'vehicle' and 'passenger' expressions for vehicle enter/exit events?
 	static { // It was necessary to convert to SimpleExpression due to the method 'isSingle()'.
 		Skript.registerExpression(ExprPassenger.class, Entity.class, ExpressionType.PROPERTY, "[the] passenger[s] of %entities%", "%entities%'[s] passenger[s]");

--- a/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprPassenger.java
@@ -19,12 +19,18 @@
  */
 package ch.njol.skript.expressions;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.eclipse.jdt.annotation.Nullable;
 
+import ch.njol.skript.Skript;
+import ch.njol.skript.bukkitutil.PassengerUtils;
 import ch.njol.skript.classes.Changer.ChangeMode;
 import ch.njol.skript.classes.Converter;
 import ch.njol.skript.doc.Description;
@@ -34,6 +40,11 @@ import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.Delay;
 import ch.njol.skript.entity.EntityData;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 
 /**
@@ -41,37 +52,121 @@ import ch.njol.util.coll.CollectionUtils;
  */
 @Name("Passenger")
 @Description({"The passenger of a vehicle, or the rider of a mob.",
-		"See also: <a href='#ExprVehicle'>vehicle</a>"})
-@Examples({"passenger of the minecart is a creeper or a cow",
-		"the saddled pig's passenger is a player"})
-@Since("2.0")
-public class ExprPassenger extends SimplePropertyExpression<Entity, Entity> { // REMIND create 'vehicle' and 'passenger' expressions for vehicle enter/exit events?
-	static {
-		register(ExprPassenger.class, Entity.class, "passenger[s]", "entities");
+		"See also: <a href='#ExprVehicle'>vehicle</a>",
+		"For 1.10 and above, it returns a list of passengers and you can use all changers in it."})
+@Examples({"#for 1.9",
+		"passenger of the minecart is a creeper or a cow",
+		"the saddled pig's passenger is a player",
+		"#for 1.10 +",
+		"passengers of the minecart contains a creeper or a cow",
+		"the boat's passenger contains a pig",
+		"add a cow and a zombie to passengers of last spawned boat",
+		"set passengers of player's vehicle to a pig and a horse",
+		"remove all pigs from player's vehicle",
+		"clear passengers of boat"})
+@Since("2.0, 2.2-dev26 (Multiple passengers for 1.10+)")
+public class ExprPassenger extends SimpleExpression<Entity> { // REMIND create 'vehicle' and 'passenger' expressions for vehicle enter/exit events?
+	static { // It was necessary to convert to SimpleExpression due to the method 'isSingle()'.
+		Skript.registerExpression(ExprPassenger.class, Entity.class, ExpressionType.PROPERTY, "[the] passenger[s] of %entities%", "%entities%'[s] passenger[s]");
 	}
 	
-	@Override
-	protected Entity[] get(final Event e, final Entity[] source) {
-		return get(source, new Converter<Entity, Entity>() {
-			@Override
-			@Nullable
-			public Entity convert(final Entity v) {
-				if (getTime() >= 0 && e instanceof VehicleEnterEvent && v.equals(((VehicleEnterEvent) e).getVehicle()) && !Delay.isDelayed(e)) {
-					return ((VehicleEnterEvent) e).getEntered();
-				}
-				if (getTime() >= 0 && e instanceof VehicleExitEvent && v.equals(((VehicleExitEvent) e).getVehicle()) && !Delay.isDelayed(e)) {
-					return ((VehicleExitEvent) e).getExited();
-				}
-				return v.getPassenger();
-			}
-		});
-	}
+	@SuppressWarnings("null")
+	private Expression<Entity> vehicle;
 	
 	@Override
 	@Nullable
-	public Entity convert(final Entity e) {
-		assert false;
-		return e.getPassenger();
+	protected Entity[] get(Event e) {
+		Entity[] source = vehicle.getAll(e);
+		Converter<Entity, Entity[]> conv = new Converter<Entity, Entity[]>(){
+			@Override
+			@Nullable
+			public Entity[] convert(Entity v) {
+				if (getTime() >= 0 && e instanceof VehicleEnterEvent && v.equals(((VehicleEnterEvent) e).getVehicle()) && !Delay.isDelayed(e)) {
+					return new Entity[] {((VehicleEnterEvent) e).getEntered()};
+				}
+				if (getTime() >= 0 && e instanceof VehicleExitEvent && v.equals(((VehicleExitEvent) e).getVehicle()) && !Delay.isDelayed(e)) {
+					return new Entity[] {((VehicleExitEvent) e).getExited()};
+				}
+				return PassengerUtils.getPassenger(v);
+			}};
+			
+		List<Entity> entities = new ArrayList<>();
+		for (Entity v : source) {
+			if (v == null)
+				continue;
+			Entity[] array = conv.convert(v);
+			if (array != null && array.length > 0)
+				entities.addAll(Arrays.asList(array));
+		}
+		return entities.toArray(new Entity[entities.size()]);
+	}
+	
+	
+	@SuppressWarnings({"unchecked", "null"})
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
+		vehicle = (Expression<Entity>) exprs[0];
+		return true;
+	}
+
+	@Override
+	@Nullable
+	public Class<?>[] acceptChange(final ChangeMode mode) {
+		if (!isSingle())
+			return new Class[] {Entity[].class, EntityData[].class}; // To support more than one entity
+		if (mode == ChangeMode.SET)
+			return new Class[] {Entity.class, EntityData.class};
+		return super.acceptChange(mode);
+	}
+
+	@SuppressWarnings("null")
+	@Override
+	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
+		Entity[] vehicles = this.vehicle.getArray(e);
+		if (!isSingle() || mode == ChangeMode.SET) {
+			for (Entity vehicle: vehicles){
+				if (vehicle == null)
+					continue;
+				switch(mode){
+					case SET: 
+						vehicle.eject();
+						//$FALL-THROUGH$
+					case ADD:
+						if (delta == null || delta.length == 0)
+							return;
+						for (Object obj : delta){
+							if (obj == null)
+								continue;
+							Entity passenger = obj instanceof Entity ? (Entity)obj: ((EntityData<?>)obj).spawn(vehicle.getLocation());
+							PassengerUtils.addPassenger(vehicle, passenger);
+						}
+						break;
+					case REMOVE_ALL:
+					case REMOVE:
+						if (delta == null || delta.length == 0)
+							return;
+						for (Object obj : delta){
+							if (obj == null)
+								continue;
+							if (obj instanceof Entity){
+								PassengerUtils.removePassenger(vehicle, (Entity)obj);
+							} else {
+								for (Entity passenger : PassengerUtils.getPassenger(vehicle))
+									if (passenger != null && ((EntityData<?>)obj).isInstance((passenger))){
+										PassengerUtils.removePassenger(vehicle, passenger);
+									}
+							}
+						}
+						break;
+					case RESET:
+					case DELETE:
+						vehicle.eject();
+				}
+			}
+		} else {
+			super.change(e, delta, mode);
+		}
+		
 	}
 	
 	@Override
@@ -80,53 +175,19 @@ public class ExprPassenger extends SimplePropertyExpression<Entity, Entity> { //
 	}
 	
 	@Override
-	@Nullable
-	public Class<?>[] acceptChange(final ChangeMode mode) {
-		if (mode == ChangeMode.SET) {
-			return new Class[] {Entity.class, EntityData.class};
-		}
-		return super.acceptChange(mode);
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the passenger of " + vehicle.toString(e, debug);
 	}
 	
 	@Override
-	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) {
-		if (mode == ChangeMode.SET) {
-			assert delta != null;
-			final Entity[] vs = getExpr().getArray(e);
-			if (vs.length == 0)
-				return;
-			final Object o = delta[0];
-			if (o instanceof Entity) {
-				((Entity) o).leaveVehicle();
-				final Entity v = CollectionUtils.getRandom(vs);
-				assert v != null;
-				v.eject();
-				v.setPassenger((Entity) o);
-			} else if (o instanceof EntityData) {
-				for (final Entity v : vs) {
-					@SuppressWarnings("null")
-					final Entity p = ((EntityData<?>) o).spawn(v.getLocation());
-					if (p == null)
-						continue;
-					v.setPassenger(p);
-				}
-			} else {
-				assert false;
-			}
-		} else {
-			super.change(e, delta, mode);
-		}
-	}
-	
-	@Override
-	protected String getPropertyName() {
-		return "passenger";
+	public boolean isSingle() {
+		// In case it doesn't have multiple passenger support, it's up to the source expression to determine if it's single, otherwise is always false
+		return !PassengerUtils.hasMultiplePassenger() ? vehicle.isSingle() : false;
 	}
 	
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean setTime(final int time) {
-		return super.setTime(time, getExpr(), VehicleEnterEvent.class, VehicleExitEvent.class);
-	}
-	
+		return super.setTime(time, vehicle, VehicleEnterEvent.class, VehicleExitEvent.class);
+	}	
 }

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -519,6 +519,27 @@ entities:
 	boat:
 		name: boat¦s
 		pattern: boat(|1¦s)
+	any boat:
+		name: boat¦s
+		pattern: any boat(|1¦s)
+	oak boat:
+		name: oak boat¦s
+		pattern: oak boat(|1¦s)	
+	spruce boat:
+		name: spruce boat¦s
+		pattern: spruce boat(|1¦s)
+	birch boat:
+		name: birch boat¦s
+		pattern: birch boat(|1¦s)
+	jungle boat:
+		name: jungle boat¦s
+		pattern: jungle boat(|1¦s)
+	acacia boat:
+		name: acacia boat¦s
+		pattern: acacia boat(|1¦s)
+	dark oak boat:
+		name: dark oak boat¦s
+		pattern: dark oak boat(|1¦s)
 	blaze:
 		name: blaze¦s
 		pattern: blaze(|1¦s)

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -701,6 +701,9 @@ entities:
 	villager:
 		name: villager¦s
 		pattern: <age> villager(|1¦s)|(4¦)[villager] (kid(|1¦s)|child(|1¦ren))
+	normal:
+		name: villager¦s
+		pattern: <age> villager(|1¦s)|(4¦)[villager] (kid(|1¦s)|child(|1¦ren))
 	farmer:
 		name: farmer¦s
 		pattern: <age> farmer(|1¦s)|(4¦)farmer (kid(|1¦s)|child(|1¦ren))


### PR DESCRIPTION
**Changes**:
* Added boat support for `1.10+`:
  * Patterns: `boat, any boat, oak boat, spruce boat, birch boat, jungle boat, acacia boat, dark oak boat`
  * `boat` and `any boat` works like a supertype when comparing, but `boat` spawns a `oak boat` and `any boat` spawns a random boat in spawn effects.
  * Also added boat to the default comparator of entity's materials to work when compared "with items".
  * Boats will return it's type when returned as string, like `oak boat`.
* Added multiple passenger support for `1.11.2+`.
  * The syntax still the same, the difference is for 1.11.2+ will return a list instead of a single entity and can accept all changers (add, remove, set...).
  * For 1.11 and lower will be the same as previously: single entity and it can only be setted.
  * Changed the syntax of `EffVehicle` to accept multiple entities when supported.
  * Created a `PassengerUtils` to handle between versions, using reflection as the methods will be removed soon.
* Added a new syntax for `last spawned entity`: `[the] [last[ly]] dropped item`
  * It was necessary just to be more friendly syntax, it was a little weird with `last spawned dropped item`.
  * Also, added the experience that are dropped from `drop effect` with `last spawned experience orb` too. (Before It was only stored when using `spawn effect`).
* Fixed a bug when checking `if a entity is a armor stand` adding a default comparator for it.
* Added `event-item` to `item spawn` event. (I was pretty sure that it was already there since 2.1)

<details><summary>Examples and test codes</summary><p>

```
spawn a boat or oak boat #Both the same
spawn a spruce boat, birch boat, jungle boat, acacia boat, dark oak boat at player
spawn any boat #Randomly

if target is any boat or a boat: #Both works return true for all boats
    send "It's a boat"
if target is a oak boat:
    send "Oak boat: true"
else if target is a birch boat:
    send "Birch boat: true"
else if target is a spruce boat:
    send "Spruce boat: true"
else if target is a jungle boat:
    send "Jungle boat: true"
else if type of target is a acacia boat:
    send "Acacia boat: true"
else if target is a dark oak boat:
    send "Dark oak boat: true"
else:
    send "None of them"

spawn any boat
add a pig, a chicken, a creeper and a creeper to passengers of last spawned boat #It doesn't have limits.
wait a second
remove all creepers from passengers of last spawned boat
wait a second
clear passengers of last spawned boat

spawn any boat
make {_player1} and {_player2} ride last spawned boat

drop a stone without velocity
push last dropped item upwards

spawn a armor stand
if last spawned entity is a armor stand:
    send "true"
else:
   send "false"

on item spawn:
    broadcast "%event-item%"
```
</p></details>
<p></p>

I considered `dev26` as next version id, they are referenced at: [here](https://github.com/bensku/Skript/pull/438/files#diff-e78eb62873567060b0cde657767e8499R59) and [here](https://github.com/bensku/Skript/pull/438/files#diff-b7b981856cf73767fc903119c84cf5fcR67)