### PR TITLE
Add a handy class that makes doing Asynchronous Effects easily.

### DIFF
--- a/src/main/java/ch/njol/skript/effects/Delay.java
+++ b/src/main/java/ch/njol/skript/effects/Delay.java
@@ -93,6 +93,10 @@ public class Delay extends Effect {
 		return delayed.contains(e);
 	}
 
+	public static void addDelayedEvent(Event event){
+		delayed.add(event);
+	}
+
 	@Override
 	protected void execute(final Event e) {
 		throw new UnsupportedOperationException();

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -36,7 +36,7 @@ public abstract class AsyncEffect extends Effect{
     @Nullable
     protected TriggerItem walk(Event e) {
         Delay.addDelayedEvent(e);
-        Executors.newSingleThreadExecutor().submit(new Runnable() {
+        new Thread(new Runnable() {
             @Override
             public void run() {
                 execute(e);
@@ -44,7 +44,7 @@ public abstract class AsyncEffect extends Effect{
                     lock.notify();
                 }
             }
-        });
+        }).start();
         synchronized (lock){
             try {
                 lock.wait();

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -45,7 +45,10 @@ public abstract class AsyncEffect extends Effect{
                 Bukkit.getScheduler().runTask(Skript.getInstance(), new Runnable() {
                     @Override
                     public void run() {
-                        TriggerItem.walk(getNext(), e);
+                        TriggerItem next = getNext();
+                        if (next != null){
+                            TriggerItem.walk(next, e);
+                        }
                     }
                 });
             }

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -25,6 +25,7 @@ import ch.njol.skript.lang.TriggerItem;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 /**
@@ -36,7 +37,7 @@ public abstract class AsyncEffect extends Effect{
     @Nullable
     protected TriggerItem walk(Event e) {
         Delay.addDelayedEvent(e);
-        new Thread(new Runnable() {
+        getExecutorService().submit(new Runnable() {
             @Override
             public void run() {
                 execute(e);
@@ -44,7 +45,7 @@ public abstract class AsyncEffect extends Effect{
                     lock.notify();
                 }
             }
-        }).start();
+        });
         synchronized (lock){
             try {
                 lock.wait();
@@ -58,4 +59,6 @@ public abstract class AsyncEffect extends Effect{
         }
         return null;
     }
+
+    public abstract ExecutorService getExecutorService();
 }

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -1,0 +1,61 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.util;
+
+import ch.njol.skript.effects.Delay;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.TriggerItem;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.concurrent.Executors;
+
+/**
+ * @author Andrew Tran
+ */
+public abstract class AsyncEffect extends Effect{
+    private final Object lock = new Object();
+    @Override
+    @Nullable
+    protected TriggerItem walk(Event e) {
+        Delay.addDelayedEvent(e);
+        Executors.newSingleThreadExecutor().submit(new Runnable() {
+            @Override
+            public void run() {
+                execute(e);
+                synchronized (lock){
+                    lock.notify();
+                }
+            }
+        });
+        synchronized (lock){
+            try {
+                lock.wait();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
+            }
+            TriggerItem next = getNext();
+            if (next != null){
+                TriggerItem.walk(next, e);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/ch/njol/skript/util/AsyncEffect.java
+++ b/src/main/java/ch/njol/skript/util/AsyncEffect.java
@@ -37,7 +37,7 @@ public abstract class AsyncEffect extends Effect{
     @Nullable
     protected TriggerItem walk(Event e) {
         Delay.addDelayedEvent(e);
-        getExecutorService().submit(new Runnable() {
+        getExecutorService().execute(new Runnable() {
             @Override
             public void run() {
                 execute(e);


### PR DESCRIPTION
This class allows you to make an effect that doesn't walk to the next trigger item until the execute method is done running. It also adds the current event to the delayed events list. If needed, I can make it optionally require the execute method to call `done()` (a new method which just walks to the next trigger item) from within it. This would be good if the execute method does an operation without blocking the current thread. I also added a public static method to [Delay](https://github.com/bensku/Skript/blob/master/src/main/java/ch/njol/skript/effects/Delay.java), so I could add the event to the delayed events list without something "hacky" like Reflection.

Class used to test this:
```java
@Name("Test")
@Description("test")
@Examples({"test"})
@Since("test")
public class EffTest extends AsyncEffect{
    private static ExecutorService executorService = Executors.newSingleThreadExecutor();

    static {
        Skript.registerEffect(EffTest.class, "test");
    }

    @Override
    public String toString(final @Nullable Event e, boolean debug) {
        return "test";
    }

    @Override
    protected void execute(Event e) {
        try {
            Thread.sleep(5000);
        } catch (InterruptedException e1) {
            e1.printStackTrace();
        }
    }

    @Override
    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
        return true;
    }

    @Override
    public ExecutorService getExecutorService() {
        return executorService;
    }
}
```
Script:
```vb
command /delay:
	trigger:
                message "In 5 seconds you should get a message!"
		test
		message "This is a message!"
```