### PR TITLE
Fixed list deletion for databases

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -388,7 +388,24 @@ public class Variable<T> implements Expression<T> {
 	public void change(final Event e, final @Nullable Object[] delta, final ChangeMode mode) throws UnsupportedOperationException {
 		switch (mode) {
 			case DELETE:
-				set(e, null);
+				assert delta != null;
+				if (list) {
+				final ArrayList<String> rem = new ArrayList<>(); 
+				final Map<String, Object> o = (Map<String, Object>) getRaw(e);
+					if (o == null)
+						return;
+					for (final Entry<String, Object> i : o.entrySet()) {
+						if (i.getKey() != null){
+						rem.add(i.getKey());
+						}
+					}
+					for (final String r : rem) {
+						assert r != null;
+						setIndex(e, r, null);
+					}
+				}else{
+					set(e, null);
+				}
 				break;
 			case SET:
 				assert delta != null;


### PR DESCRIPTION
Fixed variable list deletion for mysql  and possibly other databases. Attempting to delete variable lists from a database would lead to nothing happening. This fixes that.