### PR TITLE
Properly print command name in command already exists script error

### DIFF
--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -354,7 +354,7 @@ public abstract class Commands {
 		final ScriptCommand existingCommand = commands.get(command);
 		if (alsoRegister && existingCommand != null && existingCommand.getLabel().equals(command)) {
 			final File f = existingCommand.getScript();
-			Skript.error("A command with the name /" + command + " is already defined" + (f == null ? "" : " in " + f.getName()));
+			Skript.error("A command with the name /" + existingCommand.getName() + " is already defined" + (f == null ? "" : " in " + f.getName()));
 			return null;
 		}
 		
@@ -492,7 +492,7 @@ public abstract class Commands {
 		final ScriptCommand existingCommand = commands.get(command.getLabel());
 		if (existingCommand != null && existingCommand.getLabel().equals(command.getLabel())) {
 			final File f = existingCommand.getScript();
-			Skript.error("A command with the name /" + command + " is already defined" + (f == null ? "" : " in " + f.getName()));
+			Skript.error("A command with the name /" + existingCommand.getName() + " is already defined" + (f == null ? "" : " in " + f.getName()));
 			return;
 		}
 		


### PR DESCRIPTION
Target Minecraft versions: All that Skript supports
Related issues: Fixes #802 

Description:
Changes the message `A command with the name /ch.njol.skript.command.ScriptCommand@<some string> is already defined in <script>.sk` to `A command with the name of <command name> is already defined in <script>.sk`