### PR TITLE
Make the kill effect kill ender dragon (parts too) and pigs properly

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -69,7 +69,7 @@ public class EffKill extends Effect {
 			if (entity instanceof EnderDragonPart){
 				entity = ((EnderDragonPart) entity).getParent();
 			}
-			//Ender Dragons won't die via noraml damage
+			//Ender Dragons won't die via normal damage
 			if ((entity instanceof ArmorStand || entity instanceof Vehicle || entity instanceof EnderDragon) && !(entity instanceof Damageable)) {
 				entity.remove(); // Got complaints in issue tracker, so this is possible... Not sure if good idea, though!
 			} else {

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -20,12 +20,7 @@
 package ch.njol.skript.effects;
 
 import org.bukkit.GameMode;
-import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Damageable;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -55,6 +50,9 @@ public class EffKill extends Effect {
 		Skript.registerEffect(EffKill.class, "kill %entities%");
 	}
 	
+	// Absolutely make sure it dies
+	public static final int DAMAGE_AMOUNT = Integer.MAX_VALUE;
+	
 	@SuppressWarnings("null")
 	private Expression<Entity> entities;
 	
@@ -67,14 +65,23 @@ public class EffKill extends Effect {
 	
 	@Override
 	protected void execute(final Event e) {
-		for (final Entity entity : entities.getArray(e)) {
-			if (entity instanceof ArmorStand || entity instanceof Vehicle) {
+		for (Entity entity : entities.getArray(e)) {
+			if (entity instanceof EnderDragonPart){
+				entity = ((EnderDragonPart) entity).getParent();
+			}
+			//Ender Dragons won't die via noraml damage
+			if ((entity instanceof ArmorStand || entity instanceof Vehicle || entity instanceof EnderDragon) && !(entity instanceof Damageable)) {
 				entity.remove(); // Got complaints in issue tracker, so this is possible... Not sure if good idea, though!
-			} else if (entity instanceof Damageable) {
+			} else {
 				final boolean creative = entity instanceof Player && ((Player) entity).getGameMode() == GameMode.CREATIVE;
 				if (creative)
 					((Player) entity).setGameMode(GameMode.SURVIVAL);
-				HealthUtils.damage((Damageable) entity, HealthUtils.getMaxHealth((LivingEntity) entity) * 100); // just to make sure that it really dies >:)
+				// Edge cases, where the entity is damageable but not living
+				if (entity instanceof LivingEntity){
+					HealthUtils.damage((Damageable) entity, HealthUtils.getMaxHealth((LivingEntity) entity) * 100); // just to make sure that it really dies >:)
+				}else{
+					HealthUtils.damage((Damageable) entity, DAMAGE_AMOUNT);
+				}
 				if (creative)
 					((Player) entity).setGameMode(GameMode.CREATIVE);
 			}


### PR DESCRIPTION
Related issues: Fixes #783

Description:
The kill effect was not killing pigs via damage because pigs are vehicles. I fixed this by checking if it also was not damageable. When I was trying to reproduce the bug, I also noticed that ender dragons + their parts were not being killed properly because ender dragons won't die via damage (at least in my testing) and the parts couldn't be cast to living entities to get their max health.