### PR TITLE
Localize how null values show up in strings

### DIFF
--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import ch.njol.skript.localization.Language;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
@@ -580,10 +579,10 @@ public abstract class Classes {
 	private final static <T> String toString(final @Nullable T o, final StringMode mode, final int flags) {
 		assert flags == 0 || mode == StringMode.MESSAGE;
 		if (o == null)
-			return Language.get("none");
+			return "<none>";
 		if (o.getClass().isArray()) {
 			if (((Object[]) o).length == 0)
-				return Language.get("none");
+				return "<none>";
 			final StringBuilder b = new StringBuilder();
 			boolean first = true;
 			for (final Object i : (Object[]) o) {

--- a/src/main/java/ch/njol/skript/registrations/Classes.java
+++ b/src/main/java/ch/njol/skript/registrations/Classes.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import ch.njol.skript.localization.Language;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
@@ -579,10 +580,10 @@ public abstract class Classes {
 	private final static <T> String toString(final @Nullable T o, final StringMode mode, final int flags) {
 		assert flags == 0 || mode == StringMode.MESSAGE;
 		if (o == null)
-			return "<none>";
+			return Language.get("none");
 		if (o.getClass().isArray()) {
 			if (((Object[]) o).length == 0)
-				return "<none>";
+				return Language.get("none");
 			final StringBuilder b = new StringBuilder();
 			boolean first = true;
 			for (final Object i : (Object[]) o) {

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -14,6 +14,9 @@ not: not
 neither: neither
 nor: nor
 
+# What null (nothing) should show up as in a string/text
+none: <none>
+
 genders:
 	0:
 		id: a

--- a/src/main/resources/lang/english.lang
+++ b/src/main/resources/lang/english.lang
@@ -14,9 +14,6 @@ not: not
 neither: neither
 nor: nor
 
-# What null (nothing) should show up as in a string/text
-none: <none>
-
 genders:
 	0:
 		id: a

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -12,9 +12,6 @@ not: nicht
 neither: weder
 nor: noch
 
-# What null (nothing) should show up as in a string/text
-none: <nichts>
-
 genders:
 	0:
 		id: n

--- a/src/main/resources/lang/german.lang
+++ b/src/main/resources/lang/german.lang
@@ -12,6 +12,9 @@ not: nicht
 neither: weder
 nor: noch
 
+# What null (nothing) should show up as in a string/text
+none: <nichts>
+
 genders:
 	0:
 		id: n


### PR DESCRIPTION
Related issues: Add enhancement #646 

Description:
Localizes how null values (nothing) show up in strings.
