### PR TITLE
Fix @Since for ExprHash

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprHash.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprHash.java
@@ -55,7 +55,7 @@ import ch.njol.util.Kleenean;
 		"			message \"login successful.\"",
 		"		else:",
 		"			message \"wrong password!\""})
-@Since("2.0 (2.2-dev32 for algorithms other than SHA-256)")
+@Since("2.0 (2.2-dev32 for algorithms other than MD5)")
 public class ExprHash extends PropertyExpression<String, String> {
 	static {
 		Skript.registerExpression(ExprHash.class, String.class, ExpressionType.SIMPLE,


### PR DESCRIPTION
This PR corrects `@Since` for ExprHash.
(see [my comment](https://github.com/bensku/Skript/commit/8739d231a80b99e627f27f01d7b7b2ffa700a84c#commitcomment-24490474) on last commit)
