### PR TITLE
Always print a stacktrace when a plugin hook error occurs

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -342,7 +342,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					}
 				} catch (final Exception e) {
 					error("Error while loading plugin hooks" + (e.getLocalizedMessage() == null ? "" : ": " + e.getLocalizedMessage()));
-					e.printStackTrace();
+					Skript.exception(e);
 				}
 				
 				Language.setUseLocal(false);

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -342,8 +342,7 @@ public final class Skript extends JavaPlugin implements Listener {
 					}
 				} catch (final Exception e) {
 					error("Error while loading plugin hooks" + (e.getLocalizedMessage() == null ? "" : ": " + e.getLocalizedMessage()));
-					if (testing())
-						e.printStackTrace();
+					e.printStackTrace();
 				}
 				
 				Language.setUseLocal(false);


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: None

Description:
Currently, if a plugin hook fails Skript gives a vague `Error while loading plugin hooks` error and doesn't print the stacktrace unless Skript's verbosity is set to debug. This PR makes it print regardless of Skript's verbosity settings.