### PR TITLE
Fix Typo in Exception Format

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -1248,7 +1248,7 @@ public final class Skript extends JavaPlugin implements Listener {
 		logEx(info);
 		logEx();
 		logEx("Something went horribly wrong with Skript.");
-		logEx("This issue is NOT your fault! You can't probably fix it yourself, either.");
+		logEx("This issue is NOT your fault! You probably can't fix it yourself, either.");
 		
 		// Parse something useful out of the stack trace
 		StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: None

Description:
Fixes a typo in the exception format