### PR TITLE
Add event-number EventValue for the clicked slot in an inventory clicking event

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
+++ b/src/main/java/ch/njol/skript/classes/data/BukkitEventValues.java
@@ -779,6 +779,13 @@ public final class BukkitEventValues {
 				return e.getClick();
 			}
 		}, 0);
+		EventValues.registerEventValue(InventoryClickEvent.class, Number.class, new Getter<Number, InventoryClickEvent>() {
+			@Override
+			@Nullable
+			public Number get(final InventoryClickEvent e) {
+				return e.getSlot();
+			}
+		}, 0);
 		// CraftItemEvent REMIND maybe re-add this when Skript parser is reworked?
 //		EventValues.registerEventValue(CraftItemEvent.class, ItemStack.class, new Getter<ItemStack, CraftItemEvent>() {
 //			@Override


### PR DESCRIPTION
I feel like adding event-number to the inventory clicking event is very helpful. I get Bensku has added a custom Slot class but this event doesn't have a number event value anyways, plus it seems more convenient.

Target Minecraft versions: Any
Requirements: None