### PR TITLE
Fixing ExprChatRecipients to allow multiple entries

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprChatRecipients.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprChatRecipients.java
@@ -70,7 +70,7 @@ public class ExprChatRecipients extends SimpleExpression<Player> {
 	@Override
 	public Class<?>[] acceptChange(final ChangeMode mode) {
 		if (mode == ChangeMode.ADD || mode == ChangeMode.SET || mode == ChangeMode.DELETE || mode == ChangeMode.REMOVE)
-			return CollectionUtils.array(Player.class, Player[].class);
+			return CollectionUtils.array(Player[].class);
 		return null;
 	}
 


### PR DESCRIPTION
Having both return types will default to only allowing single pass-throughs because it's the first of it's type in the acceptChange method, It will not accept multiple in this case.

Tested and found out in a bug issue I had on Discord in skript-chat #skriptdev.

Target Minecraft versions: any
Requirements: none
