### PR TITLE
Update ExprInventorySlot.java

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprInventorySlot.java
@@ -20,11 +20,9 @@
 package ch.njol.skript.expressions;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.bukkit.event.Event;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
@@ -40,9 +38,6 @@ import ch.njol.skript.util.InventorySlot;
 import ch.njol.skript.util.Slot;
 import ch.njol.util.Kleenean;
 
-/**
- *
- */
 @Name("Inventory Slot")
 @Description({"Represents a slot in a inventory. It can be used to change the item in a inventory too."})
 @Examples({"if slot 0 of player is air:",
@@ -54,7 +49,7 @@ import ch.njol.util.Kleenean;
 public class ExprInventorySlot extends SimpleExpression<Slot>{
 	
 	static {
-		Skript.registerExpression(ExprInventorySlot.class, Slot.class, ExpressionType.COMBINED, "[the] slot %number% of %inventory%","%inventory%'[s] slot %number%");
+		Skript.registerExpression(ExprInventorySlot.class, Slot.class, ExpressionType.COMBINED, "[the] slot[s] %numbers% of %inventory%","%inventory%['s] slot[s] %numbers%");
 	}
 
 	@SuppressWarnings("null")
@@ -77,17 +72,23 @@ public class ExprInventorySlot extends SimpleExpression<Slot>{
 
 	@Override
 	@Nullable
-	protected Slot[] get(Event e) {
-		Number slot = slots.getSingle(e);
-		Inventory inv = invis.getSingle(e);
-		if (inv != null && slot != null && slot.intValue() >= 0 && slot.intValue() < inv.getSize()){
-			return new Slot[]{new InventorySlot(inv, slot.intValue())};
-		}
-		return null;
+	protected Slot[] get(Event event) {
+		Inventory inventory = invis.getSingle(event);
+		Number[] inventorySlots = slots.getAll(event);
+		if (inventorySlots == null || inventory == null || inventorySlots.length < 1)
+			return null;
+		ArrayList<Slot> slots = new ArrayList<Slot>();
+		for (Number slot : inventorySlots)
+			if (slot.intValue() >= 0 && slot.intValue() < inventory.getSize())
+				slots.add(new InventorySlot(inventory, slot.intValue()));
+		if (slots == null || slots.isEmpty())
+			return null;
+		return slots.toArray(new Slot[slots.size()]);
 	}
+	
 	@Override
 	public boolean isSingle() {
-		return true;
+		return slots.isSingle();
 	}
 
 	@Override
@@ -97,7 +98,6 @@ public class ExprInventorySlot extends SimpleExpression<Slot>{
 	
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "slot " + slots.toString(e, debug) + " of " + invis.toString(e, debug);
+		return "slots " + slots.toString(e, debug) + " of " + invis.toString(e, debug);
 	}
-	
 }


### PR DESCRIPTION
Added support for multiple set slots.

**Example:**
```
set slots numbers between 0 and 8 of {_inventory} to light green stained glass pane
set slot 5 of {_inventory} to stone named "&6Testing"
broadcast "%slots numbers between 0 and 8 of {_inventory}%"
```

I tested this and when setting it just seemed to work without defining the accecptChange and stuff. I think the Slot type has the ability to support this, so that's why I just let it happen. You can test if it you want. This would be really helpful in Skript to have. Less looping.

Target Minecraft versions: any
Requirements: none
