### PR TITLE
Allow variables with index in function parameters

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -103,7 +103,7 @@ public abstract class Functions {
 	
 	@SuppressWarnings("null")
 	private final static Pattern functionPattern = Pattern.compile("function (" + functionNamePattern + ")\\((.*)\\)(?: :: (.+))?", Pattern.CASE_INSENSITIVE),
-			paramPattern = Pattern.compile("\\s*(.+?)\\s*:\\s*(.+?)(?:\\s*=\\s*(.+))?\\s*");
+			paramPattern = Pattern.compile("\\s*(.+?)\\s*:(?=[^:]*$)\\s*(.+?)(?:\\s*=\\s*(.+))?\\s*");
 	
 	/**
 	 * Loads a function from given node.

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -169,7 +169,6 @@ public abstract class Functions {
 				if (!n.matches())
 					return signError("The " + StringUtils.fancyOrderNumber(params.size() + 1) + " argument's definition is invalid. It should look like 'name: type' or 'name: type = default value'.");
 				final String paramName = "" + n.group(1);
-				String rParamName = paramName.endsWith("*") ? paramName.substring(0, paramName.length() - 1) + "1" : paramName;
 				for (final Parameter<?> p : params) {
 					if (p.name.toLowerCase(Locale.ENGLISH).equals(paramName.toLowerCase(Locale.ENGLISH)))
 						return signError("Each argument's name must be unique, but the name '" + paramName + "' occurs at least twice.");
@@ -181,7 +180,9 @@ public abstract class Functions {
 					c = Classes.getClassInfoFromUserInput(pl.getFirst());
 				if (c == null)
 					return signError("Cannot recognise the type '" + n.group(2) + "'");
-				final Parameter<?> p = Parameter.newInstance(rParamName, c, !paramName.endsWith("*") ? pl.getSecond() : !pl.getSecond(), n.group(3));
+				String rParamName = paramName.endsWith("*") ? paramName.substring(0, paramName.length() - 3) +
+									(!pl.getSecond() ? "::1" : "") : paramName;
+				final Parameter<?> p = Parameter.newInstance(rParamName, c, !pl.getSecond(), n.group(3));
 				if (p == null)
 					return null;
 				params.add(p);

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -168,7 +168,7 @@ public abstract class Functions {
 				final Matcher n = paramPattern.matcher(arg);
 				if (!n.matches())
 					return signError("The " + StringUtils.fancyOrderNumber(params.size() + 1) + " argument's definition is invalid. It should look like 'name: type' or 'name: type = default value'.");
-				final String paramName = "" + n.group(1);
+				final String paramName = "" + (n.group(1).endsWith("*") ? n.group(1).substring(0, n.group(1).length() - 3) : n.group(1));
 				for (final Parameter<?> p : params) {
 					if (p.name.toLowerCase(Locale.ENGLISH).equals(paramName.toLowerCase(Locale.ENGLISH)))
 						return signError("Each argument's name must be unique, but the name '" + paramName + "' occurs at least twice.");

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -169,7 +169,7 @@ public abstract class Functions {
 				if (!n.matches())
 					return signError("The " + StringUtils.fancyOrderNumber(params.size() + 1) + " argument's definition is invalid. It should look like 'name: type' or 'name: type = default value'.");
 				final String paramName = "" + n.group(1);
-				String rParamName = paramName.endsWith("*") ? paramName.substring(0, paramName.length() - 3) : paramName;
+				String rParamName = paramName.endsWith("*") ? paramName.substring(0, paramName.length() - 1) + "1" : paramName;
 				for (final Parameter<?> p : params) {
 					if (p.name.toLowerCase(Locale.ENGLISH).equals(paramName.toLowerCase(Locale.ENGLISH)))
 						return signError("Each argument's name must be unique, but the name '" + paramName + "' occurs at least twice.");
@@ -181,7 +181,7 @@ public abstract class Functions {
 					c = Classes.getClassInfoFromUserInput(pl.getFirst());
 				if (c == null)
 					return signError("Cannot recognise the type '" + n.group(2) + "'");
-				final Parameter<?> p = Parameter.newInstance(rParamName, c, !paramName.endsWith("*") ? !pl.getSecond() : pl.getSecond(), n.group(3));
+				final Parameter<?> p = Parameter.newInstance(rParamName, c, !paramName.endsWith("*") ? pl.getSecond() : !pl.getSecond(), n.group(3));
 				if (p == null)
 					return null;
 				params.add(p);

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -168,7 +168,8 @@ public abstract class Functions {
 				final Matcher n = paramPattern.matcher(arg);
 				if (!n.matches())
 					return signError("The " + StringUtils.fancyOrderNumber(params.size() + 1) + " argument's definition is invalid. It should look like 'name: type' or 'name: type = default value'.");
-				final String paramName = "" + (n.group(1).endsWith("*") ? n.group(1).substring(0, n.group(1).length() - 3) : n.group(1));
+				final String paramName = "" + n.group(1);
+				String rParamName = paramName.endsWith("*") ? paramName.substring(0, paramName.length() - 3) : paramName;
 				for (final Parameter<?> p : params) {
 					if (p.name.toLowerCase(Locale.ENGLISH).equals(paramName.toLowerCase(Locale.ENGLISH)))
 						return signError("Each argument's name must be unique, but the name '" + paramName + "' occurs at least twice.");
@@ -180,7 +181,7 @@ public abstract class Functions {
 					c = Classes.getClassInfoFromUserInput(pl.getFirst());
 				if (c == null)
 					return signError("Cannot recognise the type '" + n.group(2) + "'");
-				final Parameter<?> p = Parameter.newInstance(paramName, c, !pl.getSecond(), n.group(3));
+				final Parameter<?> p = Parameter.newInstance(rParamName, c, !paramName.endsWith("*") ? !pl.getSecond() : pl.getSecond(), n.group(3));
 				if (p == null)
 					return null;
 				params.add(p);

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -59,8 +59,8 @@ public final class Parameter<T> {
 	@SuppressWarnings("unchecked")
 	@Nullable
 	public static <T> Parameter<T> newInstance(final String name, final ClassInfo<T> type, final boolean single, final @Nullable String def) {
-		if (!Variable.isValidVariableName(name, false, false)) {
-			Skript.error("An argument's name must be a valid variable name, and cannot be a list variable.");
+		if (!Variable.isValidVariableName(name, true, false)) {
+			Skript.error("An argument's name must be a valid variable name.");
 			return null;
 		}
 		Expression<? extends T> d = null;


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: #1007

Allows the usage of indexes in parameter names.