### PR TITLE
Add config option to disable warning

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -161,6 +161,7 @@ public abstract class SkriptConfig {
 	
 	public final static Option<Boolean> disableVariableConflictWarnings = new Option<Boolean>("disable variable conflict warnings", false);
 	public final static Option<Boolean> disableObjectCannotBeSavedWarnings = new Option<Boolean>("disable variable will not be saved warnings", false);
+	public final static Option<Boolean> disableMissingAndOrWarnings = new Option<Boolean>("disable variable missing and/or warnings", false);
 	
 	
 	public final static Option<Boolean> enableScriptCaching = new Option<Boolean>("enable script caching", false)

--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -39,6 +39,7 @@ import com.bekvon.bukkit.residence.commands.info;
 
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.aliases.ItemType;
@@ -68,6 +69,7 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
+
 
 /**
  * Used for parsing my custom patterns.<br>
@@ -584,7 +586,7 @@ public class SkriptParser {
 	private final static String MULTIPLE_AND_OR = "List has multiple 'and' or 'or', will default to 'and'. Use brackets if you want to define multiple lists.";
 	private final static String MISSING_AND_OR = "List is missing 'and' or 'or', defaulting to 'and'";
 	
-	private boolean suppressMissingAndOrWarnings = false;
+	private boolean suppressMissingAndOrWarnings = SkriptConfig.disableMissingAndOrWarnings.value();
 	
 	private SkriptParser suppressMissingAndOrWarnings() {
 		suppressMissingAndOrWarnings = true;

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -158,7 +158,7 @@ disable variable will not be saved warnings: false
 # By Mirre.
 
 disable variable missing and/or warnings: false
-#Disables the "List is missing 'and' or 'or', defaulting to 'and'" warning when reloading your script.
+# Disables the "List is missing 'and' or 'or', defaulting to 'and'" warning when reloading your script.
 
 soft api exceptions: false
 # Allows Skript to ignore certain actions which would normally result in thrown exceptions.

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -157,6 +157,9 @@ disable variable will not be saved warnings: false
 # Disables the "... i.e contents cannot be saved ..." warning when reloading and something in your scripts sets a variable(non local) to a value that is not serializable.
 # By Mirre.
 
+disable variable missing and/or warnings: false
+#Disables the "List is missing 'and' or 'or', defaulting to 'and'" warning when reloading your script.
+
 soft api exceptions: false
 # Allows Skript to ignore certain actions which would normally result in thrown exceptions.
 # If everything works correctly, you should keep this option disabled. It might cause problems in some cases.


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: #981

Description:
Adds a config option to disable the `List is missing 'and' or 'or', defaulting to 'and'` warning. Tested and works as expected.