### PR TITLE
Fix and enhance kill effect

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -38,19 +38,16 @@ import ch.njol.util.Kleenean;
 /**
  * @author Peter Güttinger
  */
-@Name("Kill/Erase")
-@Description({"Kills/Erases an entity.",
-		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health.",
-		"Note 2: The erase entities effect will execute the Entity#remove method which isn't the same as killing the entity, be careful when using it."})
+@Name("Kill")
+@Description({"Kills an entity.",
+		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health."})
 @Examples({"kill the player",
 		"kill all creepers in the player's world",
-		"kill all endermen, witches and bats",
-		"erase all slimes"})
-@Since("1.0, 2.2-dev33 (erase entities)")
+		"kill all endermen, witches and bats"})
+@Since("1.0")
 public class EffKill extends Effect {
 	static {
-		Skript.registerEffect(EffKill.class, "kill %entities%", 
-				      "(erase|wipe) %entities%");
+		Skript.registerEffect(EffKill.class, "kill %entities%");
 	}
 	
 	// Absolutely make sure it dies
@@ -64,11 +61,6 @@ public class EffKill extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
 		entities = (Expression<Entity>) vars[0];
-		erase = matchedPattern == 1;
-
-		if (erase && Player.class.isAssignableFrom(entities.getReturnType())) {
-			Skript.warning("Erasing a player might cause unintended behaviors, be careful about it.");
-		}
 		return true;
 	}
 	
@@ -81,7 +73,7 @@ public class EffKill extends Effect {
 				entity = ((EnderDragonPart) entity).getParent();
 			}
 			// Some entities cannot take damage but should be killable
-			if (erase || (entity instanceof Vehicle && !(entity instanceof Pig || entity instanceof AbstractHorse)) 
+			if ((entity instanceof Vehicle && !(entity instanceof Pig || entity instanceof AbstractHorse)) 
 				|| entity instanceof ArmorStand || entity instanceof EnderDragon || !(entity instanceof Damageable)) {
 				entity.remove(); // Got complaints in issue tracker, so this is possible... Not sure if good idea, though!
 			} else if (entity instanceof Damageable) {
@@ -100,7 +92,7 @@ public class EffKill extends Effect {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return erase ? "erase" : "kill" + entities.toString(e, debug);
+		return "kill" + entities.toString(e, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -47,8 +47,8 @@ import ch.njol.util.Kleenean;
 @Since("1.0")
 public class EffKill extends Effect {
 	static {
-		Skript.registerEffect(EffKill.class, "kill %entities%",
-																				 "kill %entities% without drops");
+		Skript.registerEffect(EffKill.class, "kill %entities%", 
+				      "kill %entities% without drops");
 	}
 	
 	// Absolutely make sure it dies

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -40,7 +40,7 @@ import ch.njol.util.Kleenean;
  */
 @Name("Kill")
 @Description({"Kills an entity.",
-		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health."
+		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health.",
 		"Note 2: The kill without drops effect does more than just remove the drops, be careful when using it."})
 @Examples({"kill the player",
 		"kill all creepers in the player's world",

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -38,14 +38,14 @@ import ch.njol.util.Kleenean;
 /**
  * @author Peter Güttinger
  */
-@Name("Kill")
-@Description({"Kills an entity.",
+@Name("Kill/Erase")
+@Description({"Kills/Erases an entity.",
 		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health.",
-		"Note 2: The kill without drops effect does more than just remove the drops, be careful when using it."})
+		"Note 2: The erase entities effect will execute the Entity#remove method which isn't the same as killing the entity, be careful when using it."})
 @Examples({"kill the player",
 		"kill all creepers in the player's world",
 		"kill all endermen, witches and bats",
-		"kill all slimes without drops"})
+		"erase all slimes"})
 @Since("1.0, 2.2-dev33 (erase entities)")
 public class EffKill extends Effect {
 	static {
@@ -100,7 +100,7 @@ public class EffKill extends Effect {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return "kill " + entities.toString(e, debug) + (erase ? " without drops" : "");
+		return erase ? "erase" : "kill" + entities.toString(e, debug);
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -47,7 +47,8 @@ import ch.njol.util.Kleenean;
 @Since("1.0")
 public class EffKill extends Effect {
 	static {
-		Skript.registerEffect(EffKill.class, "kill %entities%");
+		Skript.registerEffect(EffKill.class, "kill %entities%",
+																				 "kill %entities% without drops");
 	}
 	
 	// Absolutely make sure it dies
@@ -55,23 +56,28 @@ public class EffKill extends Effect {
 	
 	@SuppressWarnings("null")
 	private Expression<Entity> entities;
+	private boolean withoutDrops;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
 		entities = (Expression<Entity>) vars[0];
+		withoutDrops = matchedPattern == 1;
 		return true;
 	}
 	
 	@Override
 	protected void execute(final Event e) {
 		for (Entity entity : entities.getArray(e)) {
-			if (entity instanceof EnderDragonPart){
+
+ 
+			if (entity instanceof EnderDragonPart) {
 				entity = ((EnderDragonPart) entity).getParent();
 			}
-			
+
 			// Some entities cannot take damage but should be killable
-			if ((entity instanceof ArmorStand || entity instanceof Vehicle || entity instanceof EnderDragon || entity instanceof Pig) && !(entity instanceof Damageable)) {
+			if (withoutDrops || (entity instanceof Vehicle && !(entity instanceof Pig || entity instanceof AbstractHorse)) 
+				|| entity instanceof ArmorStand || entity instanceof EnderDragon || !(entity instanceof Damageable)) {
 				entity.remove(); // Got complaints in issue tracker, so this is possible... Not sure if good idea, though!
 			} else if (entity instanceof Damageable) {
 				final boolean creative = entity instanceof Player && ((Player) entity).getGameMode() == GameMode.CREATIVE;
@@ -89,7 +95,7 @@ public class EffKill extends Effect {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return "kill " + entities.toString(e, debug);
+		return "kill " + entities.toString(e, debug) + (withoutDrops ? " without drops" : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -46,11 +46,11 @@ import ch.njol.util.Kleenean;
 		"kill all creepers in the player's world",
 		"kill all endermen, witches and bats",
 		"kill all slimes without drops"})
-@Since("1.0, 2.2-dev33 (without drops)")
+@Since("1.0, 2.2-dev33 (erase entities)")
 public class EffKill extends Effect {
 	static {
 		Skript.registerEffect(EffKill.class, "kill %entities%", 
-				      "kill %entities% without drops");
+				      "(erase|wipe) %entities%");
 	}
 	
 	// Absolutely make sure it dies
@@ -58,13 +58,17 @@ public class EffKill extends Effect {
 	
 	@SuppressWarnings("null")
 	private Expression<Entity> entities;
-	private boolean withoutDrops;
+	private boolean erase;
 	
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] vars, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
 		entities = (Expression<Entity>) vars[0];
-		withoutDrops = matchedPattern == 1;
+		erase = matchedPattern == 1;
+
+		if (erase && Player.class.isAssignableFrom(entities.getReturnType())) {
+			Skript.warning("Erasing a player might cause unintended behaviors, be careful about it.");
+		}
 		return true;
 	}
 	
@@ -76,9 +80,8 @@ public class EffKill extends Effect {
 			if (entity instanceof EnderDragonPart) {
 				entity = ((EnderDragonPart) entity).getParent();
 			}
-
 			// Some entities cannot take damage but should be killable
-			if (withoutDrops || (entity instanceof Vehicle && !(entity instanceof Pig || entity instanceof AbstractHorse)) 
+			if (erase || (entity instanceof Vehicle && !(entity instanceof Pig || entity instanceof AbstractHorse)) 
 				|| entity instanceof ArmorStand || entity instanceof EnderDragon || !(entity instanceof Damageable)) {
 				entity.remove(); // Got complaints in issue tracker, so this is possible... Not sure if good idea, though!
 			} else if (entity instanceof Damageable) {
@@ -97,7 +100,7 @@ public class EffKill extends Effect {
 	
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		return "kill " + entities.toString(e, debug) + (withoutDrops ? " without drops" : "");
+		return "kill " + entities.toString(e, debug) + (erase ? " without drops" : "");
 	}
 	
 }

--- a/src/main/java/ch/njol/skript/effects/EffKill.java
+++ b/src/main/java/ch/njol/skript/effects/EffKill.java
@@ -40,11 +40,13 @@ import ch.njol.util.Kleenean;
  */
 @Name("Kill")
 @Description({"Kills an entity.",
-		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health."})
+		"Note: This effect does not set the entitie's health to 0 (which causes issues), but damages the entity by 100 times its maximum health."
+		"Note 2: The kill without drops effect does more than just remove the drops, be careful when using it."})
 @Examples({"kill the player",
 		"kill all creepers in the player's world",
-		"kill all endermen, witches and bats"})
-@Since("1.0")
+		"kill all endermen, witches and bats",
+		"kill all slimes without drops"})
+@Since("1.0, 2.2-dev33 (without drops)")
 public class EffKill extends Effect {
 	static {
 		Skript.registerEffect(EffKill.class, "kill %entities%", 


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: #977, #937, #934

Description:

This PR aims to (hopefully) fix the problems when killing entities that extend Damageable but cannot be killed by the damage method (blame Spigot). It also adds `kill %entities% without drops` which will directly execute the Entity#remove method on the entity. 

Tested on 1.12.2 and 1.9.0 (thanks to @Nicofisi for testing).
