### PR TITLE
Fix Previous PR

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -881,7 +881,7 @@ public class SkriptClasses {
 						}
 					}
 				}));
-		if (!Skript.isRunningMinecraft(1, 8)) {
+		if (Skript.classExists("org.bukkit.Particle")) {
 			Classes.registerClass(new ClassInfo<>(VisualEffect.class, "visualeffect")
 					.name("Visual Effect")
 					.description("A visible effect, e.g. particles.")


### PR DESCRIPTION
Target Minecraft versions: 1.9+
Requirements: None
Related issues: PR #1014 

Description:
Just noticed that Skript#isRunningMinecraft actually returns true is you are on that version *or higher*, so the previous PR broke visual effects on 1.9-1.12. I've now changed to checking if the particle class exists instead.

Sorry for not testing my previous PR thoroughly. I thought would be trivial (damn misleading method names...). At least I noticed before a new release.
