### PR TITLE
Add %timespan% ago/later expression (#1041)

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
@@ -20,6 +20,10 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
@@ -30,15 +34,22 @@ import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+@Name("Date Ago/Later")
+@Description("A date the specified timespan before/after another date.")
+@Examples({"set {_yesterday} to 1 day ago"})
+@Since("INSERT VERSION")
 public class ExprDateAgoLater extends SimpleExpression<Date> {
 
     static {
         Skript.registerExpression(ExprDateAgoLater.class, Date.class, ExpressionType.COMBINED,
-                "%timespan% (ago|in the past)", "%timespan% (later|from now)");
+                "%timespan% (ago|in the past|before [the] [date] %-date%)",
+                "%timespan% (later|(from|after) [the] [date] %-date%)");
     }
 
     @SuppressWarnings("null")
     private Expression<Timespan> timespan;
+    @SuppressWarnings("null")
+    private Expression<Date> date;
     @SuppressWarnings("null")
     private boolean ago;
 
@@ -46,10 +57,10 @@ public class ExprDateAgoLater extends SimpleExpression<Date> {
     @Override
     protected Date[] get(Event e) {
         Timespan timespan = this.timespan.getSingle(e);
-        if (timespan == null) {
+        Date date = this.date == null ? new Date() : this.date.getSingle(e);
+        if (timespan == null || date == null) {
             return null;
         }
-        Date date = new Date();
         if (ago) {
             date.subtract(timespan);
         } else {
@@ -77,6 +88,7 @@ public class ExprDateAgoLater extends SimpleExpression<Date> {
     @Override
     public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
         timespan = (Expression<Timespan>) exprs[0];
+        date = (Expression<Date>) exprs[1];
         ago = matchedPattern == 0;
         return true;
     }

--- a/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprDateAgoLater.java
@@ -1,0 +1,83 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.Date;
+import ch.njol.skript.util.Timespan;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class ExprDateAgoLater extends SimpleExpression<Date> {
+
+    static {
+        Skript.registerExpression(ExprDateAgoLater.class, Date.class, ExpressionType.COMBINED,
+                "%timespan% (ago|in the past)", "%timespan% (later|from now)");
+    }
+
+    @SuppressWarnings("null")
+    private Expression<Timespan> timespan;
+    @SuppressWarnings("null")
+    private boolean ago;
+
+    @Nullable
+    @Override
+    protected Date[] get(Event e) {
+        Timespan timespan = this.timespan.getSingle(e);
+        if (timespan == null) {
+            return null;
+        }
+        Date date = new Date();
+        if (ago) {
+            date.subtract(timespan);
+        } else {
+            date.add(timespan);
+        }
+        return new Date[]{date};
+    }
+
+    @Override
+    public boolean isSingle() {
+        return true;
+    }
+
+    @Override
+    public Class<? extends Date> getReturnType() {
+        return Date.class;
+    }
+
+    @Override
+    public String toString(@Nullable Event e, boolean debug) {
+        return timespan.toString(e, debug) + " " + (ago ? "ago" : "later");
+    }
+
+    @SuppressWarnings({"unchecked", "null"})
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        timespan = (Expression<Timespan>) exprs[0];
+        ago = matchedPattern == 0;
+        return true;
+    }
+}


### PR DESCRIPTION
Related issues: Adds enhancement #1041 

Description:
Adds an expression that returns a Date (ch.njol.skript.util.Date) that is a timespan before/after the current Date.

Syntaxes:
```
%timespan% (ago|in the past)
%timespan% (later|from now)
```
