### PR TITLE
In changer of ExprYawPitch, if 0 is passed, keep it as 0

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprYawPitch.java
@@ -113,7 +113,7 @@ public class ExprYawPitch extends SimplePropertyExpression<Location, Number> {
 	
 		//Some random method decided to use for converting to positive values.
 		public float convertToPositive(float f) {
-			if (f * -1 == Math.abs(f))
+			if (f != 0 && f * -1 == Math.abs(f))
 				return 360 + f;
 			return f;
 		}	


### PR DESCRIPTION
Related issues: Fixes #1033

Description:
Before, the changer would convert 0 to 360, when 0 was a perfectly acceptable value for [Location#setYaw](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Location.html#setYaw-float-).
