### PR TITLE
Adds Damage Event call to the Damage Effects

### DIFF
--- a/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
+++ b/src/main/java/ch/njol/skript/bukkitutil/HealthUtils.java
@@ -147,11 +147,20 @@ public abstract class HealthUtils {
 			return;
 		}
 		if (supportsDoubles) {
-			e.damage(d * 2);
+			EntityDamageEvent ede = new EntityDamageEvent(e, DamageCause.CUSTOM, d*2);
+			Bukkit.getPluginManager().callEvent(ede);
+			if (!ede.isCancelled()) {
+				e.damage(ede.getDamage());
+			}
 			return;
 		}
 		try {
-			damage.invoke(e, (int) Math.round(d * 2));
+
+			EntityDamageEvent ede = new EntityDamageEvent(e, DamageCause.CUSTOM, d*2);
+			Bukkit.getPluginManager().callEvent(ede);
+			if (!ede.isCancelled()) {
+				damage.invoke(e, (int) Math.round(ede.getDamage()));
+			}
 		} catch (final IllegalAccessException ex) {
 			Skript.exception(ex);
 		} catch (final IllegalArgumentException ex) {
@@ -160,7 +169,6 @@ public abstract class HealthUtils {
 			Skript.exception(ex);
 		}
 	}
-	
 	/**
 	 * @param e
 	 * @param h Amount of hearts to heal


### PR DESCRIPTION
Currently, the e.damage function does not call the Damage Event, allowing users to bypass any cancellations of the events that they thought that they have in place. A simple test for this is as follows;

```
on damage:
    cancel event
 command /hurtme [<text>]:
    trigger:
        damage player by 5
```

From my testing, the player will still be damaged, despite the damage event being cancelled. This change will force Skript to respect the cancellation of the event, prior to the damage being dealt.

*before submitting, remove all help text like this*

Target Minecraft versions: *any means 1.9+*
Requirements: *is Paper required? are there plugin requirements?*
Related issues: *include issue numbers (if any) like #NUMBER*

Description:
*fill something useful that describes your pull request here*
