### PR TITLE
Fix variable saving

### DIFF
--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -435,12 +435,15 @@ public class FlatFileStorage extends VariablesStorage {
 			} else {
 				final String name = (e.getKey() == null ? parent.substring(0, parent.length() - Variable.SEPARATOR.length()) : parent + e.getKey());
 				for (final VariablesStorage s : Variables.storages) {
-					if (s != this && s.accept(name))
+					if (s.accept(name)) {
+						if (s == this) {
+							final SerializedVariable.Value value = Classes.serialize(val);
+							if (value != null)
+								writeCSV(pw, name, value.type, encode(value.data));
+						}
 						continue outer;
+					}
 				}
-				final SerializedVariable.Value value = Classes.serialize(val);
-				if (value != null)
-					writeCSV(pw, name, value.type, encode(value.data));
 			}
 		}
 	}


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: Fixes the bug explained in #1049 
Description: Variables are saved to the right .csv file on server stop.