### PR TITLE
Fix $ sign issues in options and replace effect

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -892,7 +892,7 @@ final public class ScriptLoader {
 					Skript.error("undefined option " + m.group());
 					return m.group();
 				}
-				return option;
+				return Matcher.quoteReplacement(option);
 			}
 		});
 		assert r != null;

--- a/src/main/java/ch/njol/skript/effects/EffReplace.java
+++ b/src/main/java/ch/njol/skript/effects/EffReplace.java
@@ -21,6 +21,7 @@ package ch.njol.skript.effects;
 
 import java.util.Map.Entry;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
@@ -94,7 +95,7 @@ public class EffReplace extends Effect {
 			for (int x = 0; x < haystack.length; x++)
 				for (final Object n : needles) {
 					assert n != null;
-					haystack[x] = StringUtils.replace((String)haystack[x], (String)n, (String)replacement, SkriptConfig.caseSensitive.value());
+					haystack[x] = StringUtils.replace((String)haystack[x], (String)n, Matcher.quoteReplacement((String)replacement), SkriptConfig.caseSensitive.value());
 				}
 			this.haystack.change(e, haystack, ChangeMode.SET);
 		} else {


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: #1072

Description:
now you can use $ signs without weird behavior yay