### PR TITLE
Config option to disable "Starting a variable's name with an expression" warnings

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -162,7 +162,7 @@ public abstract class SkriptConfig {
 	public final static Option<Boolean> disableVariableConflictWarnings = new Option<Boolean>("disable variable conflict warnings", false);
 	public final static Option<Boolean> disableObjectCannotBeSavedWarnings = new Option<Boolean>("disable variable will not be saved warnings", false);
 	public final static Option<Boolean> disableMissingAndOrWarnings = new Option<Boolean>("disable variable missing and/or warnings", false);
-	
+	public final static Option<Boolean> disableVariableStartingWithExpressionWarnings = new Option<Boolean>("disable starting a variable's name with an expression warnings", false);
 	
 	public final static Option<Boolean> enableScriptCaching = new Option<Boolean>("enable script caching", false)
 			.optional(true);

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -309,8 +309,11 @@ public class VariableString implements Expression<String> {
 			return;
 		if (name.startsWith("%")) {// inside the if to only print this message once per variable
 			final Config script = ScriptLoader.currentScript;
-			if (script != null)
-				Skript.warning("Starting a variable's name with an expression is discouraged ({" + name + "}). You could prefix it with the script's name: {" + StringUtils.substring(script.getFileName(), 0, -3) + "." + name + "}");
+			if (script != null) {
+				if (!SkriptConfig.disableVariableStartingWithExpressionWarnings.value()) {
+					Skript.warning("Starting a variable's name with an expression is discouraged ({" + name + "}). You could prefix it with the script's name: {" + StringUtils.substring(script.getFileName(), 0, -3) + "." + name + "}");
+				}
+			}
 		}
 		
 		final Pattern pattern;

--- a/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
+++ b/src/main/java/ch/njol/skript/variables/FlatFileStorage.java
@@ -435,12 +435,15 @@ public class FlatFileStorage extends VariablesStorage {
 			} else {
 				final String name = (e.getKey() == null ? parent.substring(0, parent.length() - Variable.SEPARATOR.length()) : parent + e.getKey());
 				for (final VariablesStorage s : Variables.storages) {
-					if (s != this && s.accept(name))
+					if (s.accept(name)) {
+						if (s == this) {
+							final SerializedVariable.Value value = Classes.serialize(val);
+							if (value != null)
+								writeCSV(pw, name, value.type, encode(value.data));
+						}
 						continue outer;
+					}
 				}
-				final SerializedVariable.Value value = Classes.serialize(val);
-				if (value != null)
-					writeCSV(pw, name, value.type, encode(value.data));
 			}
 		}
 	}

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -85,7 +85,7 @@ allow ops to use effect commands: false
 player variable fix: true
 #Whether to enable the player variable fix if a player has rejoined and was reciding inside a variable.
 #Player objects inside a variable(list or normal) are not updated to the new player object
-#A server creates whenever a player rejoins. 
+#A server creates whenever a player rejoins.
 #Basicly the variable holds the old player object when a player has rejoined thus rendering the variable kinda broken.
 #This fix should work around that and whenever a invalid(old) player object is attempted to be get through a variable
 #It will check if the player is online and then get the valid(new) player object and update the variable object to that one.
@@ -160,6 +160,9 @@ disable variable will not be saved warnings: false
 disable variable missing and/or warnings: false
 # Disables the "List is missing 'and' or 'or', defaulting to 'and'" warning when reloading your script.
 
+disable starting a variable's name with an expression warnings: false
+# Disables the "Starting a variable's name with an expression is discouraged..." warnings
+
 soft api exceptions: false
 # Allows Skript to ignore certain actions which would normally result in thrown exceptions.
 # If everything works correctly, you should keep this option disabled. It might cause problems in some cases.
@@ -195,15 +198,15 @@ databases:
 	# and install it in your server's plugin directory like other plugins.
 	#
 	# Please note that '/skript reload' will not reload this section, i.e. you'll have to restart Skript for changes to take effect.
-	
+
 	# Each database definition must be in a separate section. You can choose any name for the sections, as long as it's not already used.
 	database 1:
 		# An example database to describe all possible options.
-		
+
 		type: disabled
 		# The type of this database. Allowed values are 'CSV', 'SQLite', 'MySQL' and 'disabled'.
 		# CSV uses a text file to store the variables, while SQLite and MySQL use databases, and 'disabled' makes Skript ignore the database as if it wasn't defined at all.
-		
+
 		pattern: .*
 		# Defines which variables to save in this database.
 		# This pattern uses Regex syntax, e.g. use 'db_.*' (without the quotes) to store all variables prefixed with 'db_' in this database,
@@ -211,12 +214,12 @@ databases:
 		# Please note that variables are only stored in one database, and databases are checked from top to bottom,
 		# e.g. if a variable matches the topmost database's pattern it will be saved there and nowhere else.
 		# BTW: Patterns are checked in a separate thread, i.e. your server likely won't run slower when using complicated patterns.
-		
+
 		monitor changes: false
 		monitor interval: 20 seconds
 		# If 'monitor changes' is set to true, variables will repeatedly be checked for updates in the database (in intervals set in 'monitor interval').
 		# ! Please note that you should set 'pattern', 'monitor changes' and 'monitor interval' to the same values on all servers that access the same database!
-		
+
 		# == MySQL configuration ==
 		host: localhost # Where the database server is located at, e.g. 'example.com', 'localhost', or '192.168.1.100'
 		port: 3306 # 3306 is MySQL's default port, i.e. you likely won't need to change this value
@@ -239,16 +242,16 @@ databases:
 		# Creates a backup of the file every so often. This can be useful if you ever want to revert variables to an older state.
 		# Variables are saved constantly no matter what is set here, thus a server crash will never make you loose any variables.
 		# Set this to 0 to disable this feature.
-		
-	
+
+
 	MySQL example:
 		# A MySQL database example, with options unrelated to MySQL removed.
-		
+
 		type: disabled # change to line below to enable this database
 		# type: MySQL
-		
+
 		pattern: synced_.* # this pattern will save all variables that start with 'synced_' in this MySQL database.
-		
+
 		host: localhost
 		port: 3306
 		user: root
@@ -258,15 +261,15 @@ databases:
 
 		monitor changes: true
 		monitor interval: 20 seconds
-	
+
 	SQLite example:
 		# An SQLite database example.
-		
+
 		type: disabled # change to line below to enable this database
 		# type: SQLite
-		
+
 		pattern: db_.* # this pattern will save all variables that start with 'db_' in this SQLite database.
-		
+
 		file: ./plugins/Skript/variables.db
 		# SQLite databases must end in '.db'
 		#table: variables21
@@ -275,20 +278,20 @@ databases:
 		backup interval: 0 # 0 = don't create backups
 		monitor changes: false
 		monitor interval: 20 seconds
-	
+
 	default:
 		# The default "database" is a simple text file, with each variable on a separate line and the variable's name, type, and value separated by commas.
 		# This is the last database in this list to catch all variables that have not been saved anywhere else.
 		# You can modify this database freely, but make sure to know what you're doing if you don't want to loose any variables.
-		
+
 		type: CSV
-		
+
 		pattern: .*
-		
+
 		file: ./plugins/Skript/variables.csv
-		
+
 		backup interval: 2 hours
-	
+
 	# PS: If you don't want some variables to be saved in any database (e.g. variables that contain an %entity% which usually despawn when the server is shut down)
 	# you can modify the last database's pattern to not match all variables, e.g. use '(?!x_).*' to match all variables that don't start with 'x_'.
 	# Be very cautious when doing this however as unsaved variables cannot be recovered after the server has been stopped.


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: none
Related issues: didn't find any

Description:
Adds an option to the config to disable "Starting a variable's name with an expression is discouraged..." warnings.
