### PR TITLE
Fix sounds on 1.8 and 1.9

### DIFF
--- a/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
+++ b/src/main/java/ch/njol/skript/classes/data/SkriptClasses.java
@@ -63,6 +63,7 @@ import ch.njol.skript.util.Timeperiod;
 import ch.njol.skript.util.Timespan;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.VisualEffect;
+import ch.njol.skript.util.VisualEffectDummy;
 import ch.njol.skript.util.WeatherType;
 import ch.njol.yggdrasil.Fields;
 
@@ -913,6 +914,8 @@ public class SkriptClasses {
 						}
 					})
 					.serializer(new YggdrasilSerializer<VisualEffect>()));
+		} else {
+			Classes.registerClass(new ClassInfo<>(VisualEffectDummy.class, "visualeffect"));
 		}
 	}
 	

--- a/src/main/java/ch/njol/skript/effects/EffPlaySound.java
+++ b/src/main/java/ch/njol/skript/effects/EffPlaySound.java
@@ -60,6 +60,8 @@ public class EffPlaySound extends Effect {
 	@Nullable
 	private Expression<Player> players;
 
+	private boolean useCategory;
+
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
@@ -68,6 +70,7 @@ public class EffPlaySound extends Effect {
 		pitch = (Expression<Number>) exprs[2];
 		location = (Expression<Location>) exprs[3];
 		players = (Expression<Player>) exprs[4];
+		useCategory = Skript.classExists("org.bukkit.SoundCategory");
 
 		return true;
 	}
@@ -90,11 +93,19 @@ public class EffPlaySound extends Effect {
 			if (players != null) {
 				if (soundEnum == null) {
 					for (Player p : players.getAll(e)) {
-						p.playSound(l, s, SoundCategory.MASTER, vol, pi);
+						if (useCategory) {
+							p.playSound(l, s, SoundCategory.MASTER, vol, pi);
+						} else {
+							p.playSound(l, s, vol, pi);
+						}
 					}
 				} else {
 					for (Player p : players.getAll(e)) {
-						p.playSound(l, soundEnum, SoundCategory.MASTER, vol, pi);
+						if (useCategory) {
+							p.playSound(l, soundEnum, SoundCategory.MASTER, vol, pi);
+						} else {
+							p.playSound(l, soundEnum, vol, pi);
+						}
 					}
 				}
 			} else {

--- a/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
@@ -19,5 +19,6 @@
  */
 package ch.njol.skript.util;
 
+// This class acts as a filler for the visualeffect type on Minecraft versions with org.bukkit.Particle absent
 public class VisualEffectDummy {
 }

--- a/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
@@ -19,6 +19,10 @@
  */
 package ch.njol.skript.util;
 
-// This class acts as a filler for the visualeffect type on Minecraft versions with org.bukkit.Particle absent
+/**
+ * This class is a dummy class for {@link VisualEffect} that
+ * is used to register the "visualeffect" type on Bukkit builds
+ * without org.bukkit.Particle
+ */
 public class VisualEffectDummy {
 }

--- a/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
+++ b/src/main/java/ch/njol/skript/util/VisualEffectDummy.java
@@ -1,0 +1,23 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.util;
+
+public class VisualEffectDummy {
+}


### PR DESCRIPTION
Target Minecraft versions: 1.8, 1.9
Requirements: None
Related issues: #1076 

Description:
1.8 oriented fixes:
- register visualeffect type with a dummy class if org.bukkit.Particle is missing

1.8 and 1.9 oriented fixes:
- SoundCategory didn't exist on either version, so only use it if the class exists