### PR TITLE
Allow for nullable function args

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/Function.java
+++ b/src/main/java/ch/njol/skript/lang/function/Function.java
@@ -105,7 +105,7 @@ public abstract class Function<T> {
 		for (int i = 0; i < parameters.length; i++) {
 			final Parameter<?> p = parameters[i];
 			final Object[] val = i < params.length ? params[i] : p.def != null ? p.def.getArray(e) : null;
-			if (val == null || val.length == 0)
+			if (!p.nullable && (val == null || val.length == 0))
 				return null;
 			ps[i] = val;
 		}

--- a/src/main/java/ch/njol/skript/lang/function/Functions.java
+++ b/src/main/java/ch/njol/skript/lang/function/Functions.java
@@ -173,16 +173,23 @@ public abstract class Functions {
 					if (p.name.toLowerCase(Locale.ENGLISH).equals(paramName.toLowerCase(Locale.ENGLISH)))
 						return signError("Each argument's name must be unique, but the name '" + paramName + "' occurs at least twice.");
 				}
+				String argType = n.group(2);
+				boolean nullable = false;
+				if (argType.endsWith("?")) {
+					nullable = true;
+					argType = argType.substring(0, argType.length() - 1);
+				}
+
 				ClassInfo<?> c;
-				c = Classes.getClassInfoFromUserInput("" + n.group(2));
-				final NonNullPair<String, Boolean> pl = Utils.getEnglishPlural("" + n.group(2));
+				c = Classes.getClassInfoFromUserInput("" + argType);
+				final NonNullPair<String, Boolean> pl = Utils.getEnglishPlural("" + argType);
 				if (c == null)
 					c = Classes.getClassInfoFromUserInput(pl.getFirst());
 				if (c == null)
-					return signError("Cannot recognise the type '" + n.group(2) + "'");
+					return signError("Cannot recognise the type '" + argType + "'");
 				String rParamName = paramName.endsWith("*") ? paramName.substring(0, paramName.length() - 3) +
 									(!pl.getSecond() ? "::1" : "") : paramName;
-				final Parameter<?> p = Parameter.newInstance(rParamName, c, !pl.getSecond(), n.group(3));
+				final Parameter<?> p = Parameter.newInstance(rParamName, c, !pl.getSecond(), n.group(3), nullable);
 				if (p == null)
 					return null;
 				params.add(p);

--- a/src/main/java/ch/njol/skript/lang/function/Parameter.java
+++ b/src/main/java/ch/njol/skript/lang/function/Parameter.java
@@ -41,24 +41,36 @@ public final class Parameter<T> {
 	
 	@Nullable
 	final Expression<? extends T> def;
-	
+
 	final boolean single;
-	
+
+	final boolean nullable;
+
 	@SuppressWarnings("null")
 	public Parameter(final String name, final ClassInfo<T> type, final boolean single, final @Nullable Expression<? extends T> def) {
 		this.name = name != null ? name.toLowerCase() : null;
 		this.type = type;
 		this.def = def;
 		this.single = single;
+		this.nullable = false;
 	}
-	
+
+	@SuppressWarnings("null")
+	public Parameter(final String name, final ClassInfo<T> type, final boolean single, final @Nullable Expression<? extends T> def, boolean nullable) {
+		this.name = name != null ? name.toLowerCase() : null;
+		this.type = type;
+		this.def = def;
+		this.single = single;
+		this.nullable = nullable;
+	}
+
 	public ClassInfo<T> getType() {
 		return type;
 	}
 	
 	@SuppressWarnings("unchecked")
 	@Nullable
-	public static <T> Parameter<T> newInstance(final String name, final ClassInfo<T> type, final boolean single, final @Nullable String def) {
+	public static <T> Parameter<T> newInstance(final String name, final ClassInfo<T> type, final boolean single, final @Nullable String def, @Nullable Boolean nullable) {
 		if (!Variable.isValidVariableName(name, true, false)) {
 			Skript.error("An argument's name must be a valid variable name.");
 			return null;
@@ -101,9 +113,19 @@ public final class Parameter<T> {
 			}
 //			}
 		}
-		return new Parameter<>(name, type, single, d);
+		if (nullable == null) {
+			return new Parameter<>(name, type, single, d);
+		} else {
+			return new Parameter<>(name, type, single, d, nullable);
+		}
 	}
-	
+
+	@SuppressWarnings("unchecked")
+	@Nullable
+	public static <T> Parameter<T> newInstance(final String name, final ClassInfo<T> type, final boolean single, final @Nullable String def) {
+		return newInstance(name, type, single, def, null);
+	}
+
 	public String getName() {
 		return name;
 	}

--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -82,6 +82,10 @@ public class ScriptFunction<T> extends Function<T> {
 		for (int i = 0; i < parameters.length; i++) {
 			final Parameter<?> p = parameters[i];
 			final Object[] val = params[i];
+			if (val == null || val.length == 0) {
+				continue;
+			}
+
 			if (p.single) {
 				Variables.setVariable(p.name, val[0], e, true);
 			} else {


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: #1089

Description:
Changing this behavior outright could break a lot of scripts, and as far as I can tell it was intended behavior. Also, I think that most scripters don't want to deal with null values in functions. So, I made this PR which adds the following functionality
```
function anotherTest(superString: string):
  broadcast "%{_superString}%"

function test(superString: string?):
  broadcast "%{_superString}%"

command show:
  trigger:
    test({_not set}) #broadcasts <none>
    anotherTest({_not set}) #function is never run
```