### PR TITLE
Add getter for Variable's name

### DIFF
--- a/src/main/java/ch/njol/skript/lang/Variable.java
+++ b/src/main/java/ch/njol/skript/lang/Variable.java
@@ -603,7 +603,11 @@ public class Variable<T> implements Expression<T> {
 	public boolean check(final Event e, final Checker<? super T> c) {
 		return SimpleExpression.check(getAll(e), c, false, getAnd());
 	}
-	
+
+	public VariableString getName() {
+		return name;
+	}
+
 	@Override
 	public boolean getAnd() {
 		return true;


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: None

Description:
It has become increasingly popular for addons to make async effects that store results in a variable. Right now, you have to use reflection to access the name field. This PR adds a getter so that the reliance on reflection can be removed for newer versions