### PR TITLE
Print trigger when an exception is printed

### DIFF
--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -51,6 +51,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
+import ch.njol.skript.lang.Trigger;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
@@ -1377,6 +1378,14 @@ public final class Skript extends JavaPlugin implements Listener {
 		logEx();
 		logEx("Current node: " + SkriptLogger.getNode());
 		logEx("Current item: " + (item == null ? "null" : item.toString(null, true)));
+		if (item != null && item.getTrigger() != null) {
+			Trigger trigger = item.getTrigger();
+			if (trigger != null) { // always true, but won't compile without this check
+				File script = trigger.getScript();
+				logEx("Current trigger: " + trigger.toString(null, true) + " (" + (script == null ? "null" : script.getName()) + ", line " + trigger.getLineNumber() + ")");
+			}
+		}
+		logEx();
 		logEx("Thread: " + (thread == null ? Thread.currentThread() : thread).getName());
 		logEx();
 		logEx("Language: " + Language.getName());


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: None

Description:
Unfortunately, many addon devs are lazy and/or inexperienced with the Skript API and don't provide proper `toString`s for their syntax. This makes finding the root of erroring code a lot harder than it has to be. This PR adds the trigger, it's line number and it's script to Skript#exception to help make it easier to track down erroring code.

example:
```
[14:27:11 ERROR]: #!#! [Skript] Severe Error:
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! Something went horribly wrong with Skript.
[14:27:11 ERROR]: #!#! This issue is NOT your fault! You probably can't fix it yourself, either.
[14:27:11 ERROR]: #!#! Your Minecraft version or server software appears to be unsupported by Skript (bensku's version).
[14:27:11 ERROR]: #!#! Currently only supported servers are Spigot and its forks for Minecraft 1.9 or newer.
[14:27:11 ERROR]: #!#! Other versions might work, but since you're getting this error message something is NOT working,
[14:27:11 ERROR]: #!#! nor it will work, unless you switch to supported platform.
[14:27:11 ERROR]: #!#! Issue tracker: https://github.com/bensku/Skript/issues (only if you know what you're doing!)
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! Stack trace:
[14:27:11 ERROR]: #!#! (stack trace)
[14:27:11 ERROR]: #!#! Version Information:
[14:27:11 ERROR]: #!#!   Skript: 2.2-dev32d
[14:27:11 ERROR]: #!#!   Bukkit: 1.8.8-R0.1-SNAPSHOT
[14:27:11 ERROR]: #!#!   Minecraft: 1.8.8
[14:27:11 ERROR]: #!#!   Java: 1.8.0_111 (Java HotSpot(TM) 64-Bit Server VM 25.111-b14)
[14:27:11 ERROR]: #!#!   OS: Windows 10 amd64 10.0
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! Running CraftBukkit: false
[14:27:11 ERROR]: #!#! Running Spigot (or compatible): true
[14:27:11 ERROR]: #!#! Running Paper (or compatible): true
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! Current node: null
[14:27:11 ERROR]: #!#! Current item: broadcast "%the first element of 'invalid'%"
[14:27:11 ERROR]: #!#! Current trigger: click (click) (tests.sk, line 14)
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! Thread: Server thread
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! Language: english
[14:27:11 ERROR]: #!#! Link parse mode: DISABLED
[14:27:11 ERROR]: #!#!
[14:27:11 ERROR]: #!#! End of Error.
[14:27:11 ERROR]: #!#!
```