### PR TITLE
Improve command cooldowns

### DIFF
--- a/src/main/java/ch/njol/skript/SkriptConfig.java
+++ b/src/main/java/ch/njol/skript/SkriptConfig.java
@@ -248,7 +248,7 @@ public abstract class SkriptConfig {
 				}
 				
 			});
-	
+
 	public final static Option<Boolean> asyncLoaderEnabled = new Option<Boolean>("asynchronous script loading", false)
 			.setter(new Setter<Boolean>() {
 
@@ -262,7 +262,10 @@ public abstract class SkriptConfig {
 	
 	public final static Option<Boolean> allowUnsafePlatforms = new Option<Boolean>("allow unsafe platforms", false)
 			.optional(true);
-	
+
+	public final static Option<Boolean> keepLastUsageDates = new Option<Boolean>("keep command last usage dates", false)
+			.optional(true);
+
 	/**
 	 * This should only be used in special cases
 	 */

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -37,6 +37,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import ch.njol.skript.lang.VariableString;
+import ch.njol.skript.util.StringMode;
 import ch.njol.skript.util.Timespan;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
@@ -467,7 +468,7 @@ public abstract class Commands {
 		String cooldownStorageString = ScriptLoader.replaceOptions(node.get("cooldown storage", ""));
 		VariableString cooldownStorage = null;
 		if (!cooldownStorageString.isEmpty()) {
-			cooldownStorage = VariableString.newInstance(cooldownStorageString);
+			cooldownStorage = VariableString.newInstance(cooldownStorageString, StringMode.VARIABLE_NAME);
 		}
 
 		if (Skript.debug() || node.debug())

--- a/src/main/java/ch/njol/skript/command/Commands.java
+++ b/src/main/java/ch/njol/skript/command/Commands.java
@@ -141,6 +141,7 @@ public abstract class Commands {
 			.addEntry("cooldown", true)
 			.addEntry("cooldown message", true)
 			.addEntry("cooldown bypass", true)
+			.addEntry("cooldown storage", true)
 			.addEntry("aliases", true)
 			.addEntry("executable by", true)
 			.addSection("trigger", false);
@@ -463,6 +464,12 @@ public abstract class Commands {
 			Skript.warning("command /" + command + " has a cooldown message set, but not a cooldown");
 		}
 
+		String cooldownStorageString = ScriptLoader.replaceOptions(node.get("cooldown storage", ""));
+		VariableString cooldownStorage = null;
+		if (!cooldownStorageString.isEmpty()) {
+			cooldownStorage = VariableString.newInstance(cooldownStorageString);
+		}
+
 		if (Skript.debug() || node.debug())
 			Skript.debug("command " + desc + ":");
 		
@@ -476,8 +483,8 @@ public abstract class Commands {
 		final ScriptCommand c;
 		try {
 			c = new ScriptCommand(config, command, "" + pattern.toString(), currentArguments, description, usage,
-					aliases, permission, permissionMessage, cooldown, cooldownMessage, cooldownBypass, executableBy,
-					ScriptLoader.loadItems(trigger));
+					aliases, permission, permissionMessage, cooldown, cooldownMessage, cooldownBypass, cooldownStorage,
+					executableBy, ScriptLoader.loadItems(trigger));
 		} finally {
 			Commands.currentArguments = null;
 		}

--- a/src/main/java/ch/njol/skript/command/ScriptCommand.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommand.java
@@ -33,11 +33,13 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
+import ch.njol.skript.SkriptConfig;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.util.Date;
 import ch.njol.skript.util.Timespan;
+import ch.njol.skript.variables.Variables;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -46,6 +48,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.help.GenericCommandHelpTopic;
 import org.bukkit.help.HelpMap;
 import org.bukkit.help.HelpTopic;
@@ -90,6 +93,8 @@ public class ScriptCommand implements CommandExecutor {
 	private final Timespan cooldown;
 	private final Expression<String> cooldownMessage;
 	private final String cooldownBypass;
+	@Nullable
+	private final Expression<String> cooldownStorage;
 	final String usage;
 
 	final Trigger trigger;
@@ -121,7 +126,7 @@ public class ScriptCommand implements CommandExecutor {
 						 final String description, final String usage, final ArrayList<String> aliases,
 						 final String permission, final String permissionMessage, @Nullable final Timespan cooldown,
 						 @Nullable final VariableString cooldownMessage, final String cooldownBypass,
-						 final int executableBy, final List<TriggerItem> items) {
+						 @Nullable VariableString cooldownStorage, final int executableBy, final List<TriggerItem> items) {
 		Validate.notNull(name, pattern, arguments, description, usage, aliases, items);
 		this.name = name;
 		label = "" + name.toLowerCase();
@@ -133,6 +138,7 @@ public class ScriptCommand implements CommandExecutor {
 				? new SimpleLiteral<>(Language.get("commands.cooldown message"),false)
 				: cooldownMessage;
 		this.cooldownBypass = cooldownBypass;
+		this.cooldownStorage = cooldownStorage;
 
 		final Iterator<String> as = aliases.iterator();
 		while (as.hasNext()) { // remove aliases that are the same as the command
@@ -209,13 +215,15 @@ public class ScriptCommand implements CommandExecutor {
 
 				// Cooldown bypass
 				if (!cooldownBypass.isEmpty() && player.hasPermission(cooldownBypass)) {
-					lastUsageMap.remove(uuid);
+					setLastUsage(uuid, event, null);
 					break cooldownCheck;
 				}
 
-				if (lastUsageMap.containsKey(uuid)) {
-					if (getRemainingMilliseconds(uuid) <= 0) {
-						lastUsageMap.remove(uuid);
+				if (getLastUsage(uuid, event) != null) {
+					if (getRemainingMilliseconds(uuid, event) <= 0) {
+                        if (!SkriptConfig.keepLastUsageDates.value()) {
+                        	setLastUsage(uuid, event, null);
+						}
 					} else {
 						sender.sendMessage(cooldownMessage.getSingle(event));
 						return false;
@@ -227,7 +235,7 @@ public class ScriptCommand implements CommandExecutor {
 		if (Bukkit.isPrimaryThread()) {
 			execute2(event, sender, commandLabel, rest);
 			if (sender instanceof Player && !event.isCooldownCancelled()) {
-				lastUsageMap.put(((Player) sender).getUniqueId(), new Date());
+				setLastUsage(((Player) sender).getUniqueId(), event, new Date());
 			}
 		} else {
 			// must not wait for the command to complete as some plugins call commands in such a way that the server will deadlock
@@ -236,7 +244,7 @@ public class ScriptCommand implements CommandExecutor {
 				public void run() {
 					execute2(event, sender, commandLabel, rest);
 					if (sender instanceof Player && !event.isCooldownCancelled()) {
-						lastUsageMap.put(((Player) sender).getUniqueId(), new Date());
+						setLastUsage(((Player) sender).getUniqueId(), event, new Date());
 					}
 				}
 			});
@@ -244,7 +252,7 @@ public class ScriptCommand implements CommandExecutor {
 
 		return true; // Skript prints its own error message anyway
 	}
-	
+
 	boolean execute2(final ScriptCommandEvent event, final CommandSender sender, final String commandLabel, final String rest) {
 		final ParseLogHandler log = SkriptLogger.startParseLogHandler();
 		try {
@@ -409,39 +417,82 @@ public class ScriptCommand implements CommandExecutor {
 		return cooldown;
 	}
 
-	public long getRemainingMilliseconds(UUID uuid) {
-		Date lastUsage = lastUsageMap.get(uuid);
+	@Nullable
+	private String getStorageVariableName(Event event) {
+		assert cooldownStorage != null;
+		String variableString = cooldownStorage.getSingle(event);
+		if (variableString == null) {
+			return null;
+		}
+		if (variableString.startsWith("{")) {
+			variableString = variableString.substring(1);
+		}
+		if (variableString.endsWith("}")) {
+			variableString = variableString.substring(0, variableString.length() - 1);
+		}
+		return variableString;
+	}
+
+	@Nullable
+	public Date getLastUsage(UUID uuid, Event event) {
+		if (cooldownStorage == null) {
+			return lastUsageMap.get(uuid);
+		} else {
+			String name = getStorageVariableName(event);
+			assert name != null;
+			return (Date) Variables.getVariable(name, null, false);
+		}
+	}
+
+	public void setLastUsage(UUID uuid, Event event, @Nullable Date date) {
+		if (cooldownStorage != null) {
+			// Using a variable
+			String name = getStorageVariableName(event);
+			assert name != null;
+			Variables.setVariable(name, date, null, false);
+		} else {
+			// Use the map
+			if (date == null) {
+                lastUsageMap.remove(uuid);
+            } else {
+                lastUsageMap.put(uuid, date);
+            }
+		}
+	}
+
+	public long getRemainingMilliseconds(UUID uuid, Event event) {
+		Date lastUsage = getLastUsage(uuid, event);
 		if (lastUsage == null) {
 			return 0;
 		}
 		Timespan cooldown = this.cooldown;
 		assert cooldown != null;
-		long remaining = cooldown.getMilliSeconds() - getElapsedMilliseconds(uuid);
+		long remaining = cooldown.getMilliSeconds() - getElapsedMilliseconds(uuid, event);
 		if (remaining < 0) {
 			remaining = 0;
 		}
 		return remaining;
 	}
 
-	public void setRemainingMilliseconds(UUID uuid, long milliseconds) {
+	public void setRemainingMilliseconds(UUID uuid, Event event, long milliseconds) {
 		Timespan cooldown = this.cooldown;
 		assert cooldown != null;
 		long cooldownMs = cooldown.getMilliSeconds();
 		if (milliseconds > cooldownMs) {
 			throw new IllegalArgumentException("Remaining time may not be longer than the cooldown");
 		}
-		setElapsedMilliSeconds(uuid, cooldownMs - milliseconds);
+		setElapsedMilliSeconds(uuid, event, cooldownMs - milliseconds);
 	}
 
-	public long getElapsedMilliseconds(UUID uuid) {
-		Date lastUsage = lastUsageMap.get(uuid);
+	public long getElapsedMilliseconds(UUID uuid, Event event) {
+		Date lastUsage = getLastUsage(uuid, event);
 		return lastUsage == null ? 0 : new Date().getTimestamp() - lastUsage.getTimestamp();
 	}
 
-	public void setElapsedMilliSeconds(UUID uuid, long milliseconds) {
+	public void setElapsedMilliSeconds(UUID uuid, Event event, long milliseconds) {
 		Date date = new Date();
 		date.subtract(new Timespan(milliseconds));
-		lastUsageMap.put(uuid, date);
+		setLastUsage(uuid, event, date);
 	}
 
 	public String getCooldownBypass() {

--- a/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
+++ b/src/main/java/ch/njol/skript/command/ScriptCommandEvent.java
@@ -28,7 +28,8 @@ import org.bukkit.event.HandlerList;
 public class ScriptCommandEvent extends CommandEvent {
 	
 	private final ScriptCommand skriptCommand;
-	
+	private boolean cooldownCancelled = false;
+
 	public ScriptCommandEvent(final ScriptCommand command, final CommandSender sender) {
 		super(sender, command.getLabel(), null);
 		skriptCommand = command;
@@ -42,7 +43,15 @@ public class ScriptCommandEvent extends CommandEvent {
 	public String[] getArgs() {
 		throw new UnsupportedOperationException();
 	}
-	
+
+	public boolean isCooldownCancelled() {
+		return cooldownCancelled;
+	}
+
+	public void setCooldownCancelled(boolean cooldownCancelled) {
+		this.cooldownCancelled = cooldownCancelled;
+	}
+
 	// Bukkit stuff
 	private final static HandlerList handlers = new HandlerList();
 	

--- a/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
+++ b/src/main/java/ch/njol/skript/effects/EffCancelCooldown.java
@@ -1,0 +1,83 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.effects;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.Skript;
+import ch.njol.skript.command.ScriptCommandEvent;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.log.ErrorQuality;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Cancel Command Cooldown")
+@Description({"Only usable in command events. Makes it so the current command usage isn't counted towards the cooldown."})
+@Examples({
+        "command /nick <text>:",
+        "\texecutable by: players",
+        "\tcooldown: 10 seconds",
+        "\ttrigger:",
+        "\t\tif length of arg-1 is more than 16:",
+        "\t\t\t# Makes it so that invalid arguments don't make you wait for the cooldown again",
+        "\t\t\tcancel the cooldown",
+        "\t\t\tsend \"Your nickname may be at most 16 characters.\"",
+        "\t\t\tstop",
+        "\t\tset the player's display name to arg-1"
+})
+@Since("INSERT VERSION")
+public class EffCancelCooldown extends Effect {
+    static {
+        Skript.registerEffect(EffCancelCooldown.class,
+                "(cancel|ignore) [the] [current] [command] cooldown",
+                "un(cancel|ignore) [the] [current] [command] cooldown");
+    }
+
+    private boolean cancel;
+
+    @Override
+    protected void execute(Event e) {
+        if (!(e instanceof ScriptCommandEvent)) {
+            return;
+        }
+        ((ScriptCommandEvent) e).setCooldownCancelled(cancel);
+    }
+
+    @Override
+    public String toString(@Nullable Event e, boolean debug) {
+        return (cancel ? "" : "un") + "cancel the command cooldown";
+    }
+
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        if (!ScriptLoader.isCurrentEvent(ScriptCommandEvent.class)) {
+            Skript.error("The cancel cooldown effect may only be used in a command.", ErrorQuality.SEMANTIC_ERROR);
+            return false;
+        }
+        cancel = matchedPattern == 0;
+        return true;
+    }
+}

--- a/src/main/resources/config.sk
+++ b/src/main/resources/config.sk
@@ -185,6 +185,11 @@ color codes reset formatting: true
 # With JSON-based new chat protocol, this is not necessary, but can be done
 # manually for compatibility. This is done by default for compatibility.
 
+keep command last usage dates: false
+# When a cooldown is set on a command, the last usage date is kept in memory (or in a variable if cooldown storage is specified),
+# but when the player uses the command again after the cooldown period is over, the last usage will be deleted as it's no longer needed,
+# If you need to use the expression 'last usage date', then you'll want to enable this.
+
 # ==== Variables ====
 
 databases:


### PR DESCRIPTION
Target Minecraft versions: N/A
Requirements: N/A
Related issues: PR that originally added it, #1047

Description:
- Adds `last usage date` and changers to the cooldown info expressions.
- Adds `cancel cooldown` effect
- Adds `cooldown storage` option in commands which accept a variable name (surrounding {} is optional)
- Add config.sk option to not delete the `last usage date` after command execution after cooldown period expired.
- Rename `ExprCmdElapsedRemainingTime.java` to `ExprCmdCooldownInfo.java`

Examples:
```
# Requires 'keep command last usage dates' in config.sk to be true to message last usage date and elapsed time in TRIGGER.
command /vote:
    cooldown: 24 hours
    cooldown storage: {lastvote::%uuid of sender%}
    cooldown message: You may not vote for another %remaining time%.
    trigger:
        if last usage date is set:
            send "You last voted on %last usage date%, which was %elapsed time% ago."
        send "Voting Link: https://mywebsite.com/vote.php?uuid=%uuid of sender%"
```
```
command /nick <text>:
    executable by: players
    cooldown: 10 seconds
    trigger:
        if length of arg-1 is more than 16:
            # We don't want it when nicknames are too long to count towards the cooldown
            cancel cooldown
            send "&c%arg-1% is too long!"
            stop
        set {_nick} to colored arg-1
        set display name of player to {_nick}
        send "New nick: %{_nick}%"
```