### PR TITLE
Use TravisCI again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-script: ./gradlew build test
 cache:
   directories:
     - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: java
+script: ./gradlew build test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
 script: ./gradlew build test
+cache:
+  directories:
+    - $HOME/.gradle


### PR DESCRIPTION
Target Minecraft versions: N/A
Requirements: N/A
Related issues: N/A

Description:
Caches the `.gradle` directory when TravisCI is building. TravisCI can verify that pull requests compile and pass tests properly. @bensku would need to enable it in his https://travis-ci.org account.