### PR TITLE
Fix parser issue with plurality

### DIFF
--- a/src/main/java/ch/njol/skript/lang/SkriptParser.java
+++ b/src/main/java/ch/njol/skript/lang/SkriptParser.java
@@ -438,6 +438,7 @@ public class SkriptParser {
 						// Plural/singular sanity check
 						if (hasSingular && !var.isSingle()) {
 							Skript.error("'" + expr + "' can only accept a single value of any type, not more", ErrorQuality.SEMANTIC_ERROR);
+							return null;
 						}
 						
 						log.printLog();
@@ -463,6 +464,7 @@ public class SkriptParser {
 							// Plural/singular sanity check
 							if (!vi.isPlural[i] && !var.isSingle()) {
 								Skript.error("'" + expr + "' can only accept a single " + vi.classes[i].getName() + ", not more", ErrorQuality.SEMANTIC_ERROR);
+								return null;
 							}
 							
 							log.printLog();


### PR DESCRIPTION
Target Minecraft versions: N/A
Requirements: N/A
Related issues: fixes #876 

Description:
This pull request fixes the issue that has made Skript way too lenient about plurality of expressions. 

Tested version : PaperSpigot 1.12.2
Addons : MundoSK
Test script : 
```
on script load:
    set {_list::*} to 1, 2, 3, 4 and 5
    set {_other-list::*} to integers from 0 to 10
    send "%size of {_list::*}%" to console
    send "%size of {_other-list::*}%" to console
```
Before this pull request, MundoSK's `[border] (size|diameter) of %world%` syntax (hence the presence of MundoSK) would have conflicted and Skript wouldn't have noticed. Now, Skript parses the correct expression and doesn't throw an exception, as it used to do. 

The above code prints `5` and `11` as expected.