### PR TITLE
Add PreScriptLoad event

### DIFF
--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -19,6 +19,32 @@
  */
 package ch.njol.skript;
 
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jdt.annotation.NonNull;
+
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.ClassInfo;
@@ -71,30 +97,6 @@ import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.Validate;
 import ch.njol.util.coll.CollectionUtils;
-import org.bukkit.Bukkit;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.regex.Matcher;
 
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -500,7 +500,7 @@ final public class ScriptLoader {
 			 * but before the script actually starts parsing
 			 */
 			if (callPreLoadEvent)
-				Bukkit.getPluginManager().callEvent(new PreScriptLoadEvent());
+				Bukkit.getPluginManager().callEvent(new PreScriptLoadEvent(config));
 
 //			final SerializedScript script = new SerializedScript();
 			

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -69,9 +69,11 @@ import ch.njol.util.Callback;
 import ch.njol.util.Kleenean;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
+import ch.njol.util.Validate;
 import ch.njol.util.coll.CollectionUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import java.io.File;
@@ -111,7 +113,45 @@ final public class ScriptLoader {
 	 * If true, a ScriptLoadEvent will be called
 	 * right before a script starts loading.
 	 */
-	public static boolean callPreLoadEvent;
+	private static boolean callPreLoadEvent;
+
+	/**
+	 * A List of all the SkriptAddons that have called
+	 * {@link ScriptLoader#setCallPreloadEvent(boolean, SkriptAddon)}
+	 * with true.
+	 */
+	private static List<SkriptAddon> preloadListeners = new ArrayList<>();
+
+	/**
+	 * Sets {@link ScriptLoader#callPreLoadEvent} to the provided boolean,
+	 * and adds/removes the provided SkriptAddon from {@link ScriptLoader#preloadListeners}
+	 * depending on the provided boolean (true adds, false removes).
+	 * @param state The new value for {@link ScriptLoader#callPreLoadEvent}
+	 * @param addon A non-null SkriptAddon
+	 */
+	public static void setCallPreloadEvent(boolean state, @NonNull SkriptAddon addon) {
+		Validate.notNull(addon);
+		callPreLoadEvent = state;
+		if (state) {
+			if (!preloadListeners.contains(addon))
+				preloadListeners.add(addon);
+		} else {
+			preloadListeners.remove(addon);
+		}
+	}
+
+	public static boolean getCallPreloadEvent() {
+		return callPreLoadEvent;
+	}
+
+	/**
+	 * Returns an unmodifiable list of all the addons
+	 * that have called {@link ScriptLoader#setCallPreloadEvent(boolean, SkriptAddon)}
+	 * with true.
+	 */
+	public static List<SkriptAddon> getPreloadListeners() {
+		return Collections.unmodifiableList(preloadListeners);
+	}
 
 	/**
 	 * use {@link #setCurrentEvent(String, Class...)}

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -458,9 +458,9 @@ final public class ScriptLoader {
 			 * If editing this class, please remember to put call this event
 			 * after currentScript has already been set the the provided Config
 			 */
-			if (callPreLoadEvent) {
+			if (callPreLoadEvent)
 				Bukkit.getPluginManager().callEvent(new PreScriptLoadEvent());
-			}
+
 //			final SerializedScript script = new SerializedScript();
 			
 			final CountingLogHandler numErrors = SkriptLogger.startLogHandler(new CountingLogHandler(SkriptLogger.SEVERE));

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -497,6 +497,7 @@ final public class ScriptLoader {
 			/*
 			 * If editing this class, please remember to put call this event
 			 * after currentScript has already been set the the provided Config
+			 * but before the script actually starts parsing
 			 */
 			if (callPreLoadEvent)
 				Bukkit.getPluginManager().callEvent(new PreScriptLoadEvent());

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -118,7 +118,7 @@ final public class ScriptLoader {
 	private static boolean callPreLoadEvent;
 
 	/**
-	 * A List of all the SkriptAddons that have called
+	 * A set of all the SkriptAddons that have called
 	 * {@link ScriptLoader#setCallPreloadEvent(boolean, SkriptAddon)}
 	 * with true.
 	 */

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -122,7 +122,7 @@ final public class ScriptLoader {
 	 * {@link ScriptLoader#setCallPreloadEvent(boolean, SkriptAddon)}
 	 * with true.
 	 */
-	private static List<SkriptAddon> preloadListeners = new ArrayList<>();
+	private static Set<SkriptAddon> preloadListeners = new HashSet<>();
 
 	/**
 	 * Sets {@link ScriptLoader#callPreLoadEvent} to the provided boolean,
@@ -134,12 +134,10 @@ final public class ScriptLoader {
 	public static void setCallPreloadEvent(boolean state, @NonNull SkriptAddon addon) {
 		Validate.notNull(addon);
 		callPreLoadEvent = state;
-		if (state) {
-			if (!preloadListeners.contains(addon))
-				preloadListeners.add(addon);
-		} else {
+		if (state)
+			preloadListeners.add(addon);
+		else
 			preloadListeners.remove(addon);
-		}
 	}
 
 	public static boolean getCallPreloadEvent() {
@@ -151,8 +149,8 @@ final public class ScriptLoader {
 	 * that have called {@link ScriptLoader#setCallPreloadEvent(boolean, SkriptAddon)}
 	 * with true.
 	 */
-	public static List<SkriptAddon> getPreloadListeners() {
-		return Collections.unmodifiableList(preloadListeners);
+	public static Set<SkriptAddon> getPreloadListeners() {
+		return Collections.unmodifiableSet(preloadListeners);
 	}
 
 	/**

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -19,7 +19,6 @@
  */
 package ch.njol.skript;
 
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -497,8 +497,8 @@ final public class ScriptLoader {
 			currentScript = config;
 
 			/*
-			 * If editing this class, please remember to put call this event
-			 * after currentScript has already been set the the provided Config
+			 * If editing this class, please remember to call this event
+			 * after currentScript has already been set to the provided Config,
 			 * but before the script actually starts parsing
 			 */
 			if (callPreLoadEvent)

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -19,35 +19,6 @@
  */
 package ch.njol.skript;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.regex.Matcher;
-
-import org.bukkit.Bukkit;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.aliases.Aliases;
 import ch.njol.skript.aliases.ItemType;
 import ch.njol.skript.classes.ClassInfo;
@@ -60,6 +31,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.config.SimpleNode;
 import ch.njol.skript.effects.Delay;
+import ch.njol.skript.events.bukkit.PreScriptLoadEvent;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Conditional;
 import ch.njol.skript.lang.Expression;
@@ -98,6 +70,29 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
 
 /**
  * @author Peter Güttinger
@@ -111,7 +106,13 @@ final public class ScriptLoader {
 	
 	@Nullable
 	public static Config currentScript = null;
-	
+
+	/**
+	 * If true, a ScriptLoadEvent will be called
+	 * right before a script starts loading.
+	 */
+	public static boolean callPreLoadEvent;
+
 	/**
 	 * use {@link #setCurrentEvent(String, Class...)}
 	 */
@@ -452,7 +453,14 @@ final public class ScriptLoader {
 			currentAliases.clear();
 			currentOptions.clear();
 			currentScript = config;
-			
+
+			/*
+			 * If editing this class, please remember to put call this event
+			 * after currentScript has already been set the the provided Config
+			 */
+			if (callPreLoadEvent) {
+				Bukkit.getPluginManager().callEvent(new PreScriptLoadEvent());
+			}
 //			final SerializedScript script = new SerializedScript();
 			
 			final CountingLogHandler numErrors = SkriptLogger.startLogHandler(new CountingLogHandler(SkriptLogger.SEVERE));

--- a/src/main/java/ch/njol/skript/ScriptLoader.java
+++ b/src/main/java/ch/njol/skript/ScriptLoader.java
@@ -110,8 +110,10 @@ final public class ScriptLoader {
 	public static Config currentScript = null;
 
 	/**
-	 * If true, a ScriptLoadEvent will be called
-	 * right before a script starts loading.
+	 * If true, a {@link PreScriptLoadEvent} will be called
+	 * right before a script starts parsing, but after
+	 * {@link ScriptLoader#currentScript} has been set
+	 * to a non-null {@link Config}.
 	 */
 	private static boolean callPreLoadEvent;
 

--- a/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
@@ -1,0 +1,27 @@
+package ch.njol.skript.events.bukkit;
+
+import ch.njol.skript.ScriptLoader;
+import ch.njol.skript.config.Config;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * If {@link ScriptLoader#callPreLoadEvent} is true,
+ * this event is called before a script starts
+ * loading via {@link ScriptLoader#loadScript(Config)}
+ * or one of it's overloads.
+ */
+public class PreScriptLoadEvent extends Event {
+
+    private static HandlerList handlers = new HandlerList();
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}

--- a/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
@@ -21,6 +21,7 @@ package ch.njol.skript.events.bukkit;
 
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.config.Config;
+import ch.njol.util.Validate;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -32,6 +33,13 @@ import org.bukkit.event.HandlerList;
  */
 public class PreScriptLoadEvent extends Event {
 
+    private Config script;
+
+    public PreScriptLoadEvent(Config script) {
+        Validate.notNull(script);
+        this.script = script;
+    }
+
     private static HandlerList handlers = new HandlerList();
 
     @Override
@@ -41,6 +49,15 @@ public class PreScriptLoadEvent extends Event {
 
     public static HandlerList getHandlerList() {
         return handlers;
+    }
+
+    /**
+     * This is usually, but may not be, the same
+     * as {@link ScriptLoader#currentScript}
+     * @return The {@link Config} of the loading script
+     */
+    public Config getScript() {
+        return script;
     }
 
 }

--- a/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
+++ b/src/main/java/ch/njol/skript/events/bukkit/PreScriptLoadEvent.java
@@ -1,3 +1,22 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
 package ch.njol.skript.events.bukkit;
 
 import ch.njol.skript.ScriptLoader;


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: None on this repo, but it can help addon devs fix issues like the one described in https://github.com/btk5h/skript-mirror/issues/27

Description:
This PR adds a PreScriptLoadEvent that is called when before a script starts loading, if ScriptLoader#callPreLoadEvent is true (modeled after how the bukkit event for functions is only called if Functions#callFunctionEvents is true). This is useful because it allows addon devs to mutate the currentScript Config before it begins loading, to alleviate issues like load order (similar to the ones with functions). 

Here is an example of using this:
```
    public class ScriptLoadListener {
        @EventHandler
        public void onScriptLoad(PreScriptLoadEvent e) {
            for (Node node : ScriptLoader.currentScript.getMainNode()) {
                if (node instanceof SectionNode) {
                    Matcher matcher = Pattern.compile("function (.+)\\(\\)").matcher(node.getKey());
                    if (matcher.matches()) {
                        existentFunctions.add(matcher.group(1));
                    }
                }
            }
        }
    }
```

Intellij changed import order, so if that is going to be an issue with the pending #1132 please let me know and I will try to resolve it.