### PR TITLE
Fix the send message effect to be compatible with a list of strings

### DIFF
--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -19,6 +19,12 @@
  */
 package ch.njol.skript.effects;
 
+import java.util.List;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -32,12 +38,7 @@ import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.util.Kleenean;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
-
-import java.util.List;
 
 /**
  * @author Peter Güttinger

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -53,7 +53,7 @@ import java.util.List;
 public class EffMessage extends Effect {
 	
 	static {
-		Skript.registerEffect(EffMessage.class, "(message|send [message]) %strings% [to %commandsenders%]");
+		Skript.registerEffect(EffMessage.class, "(message|send [message[s]]) %strings% [to %commandsenders%]");
 	}
 
 	@Nullable
@@ -79,17 +79,17 @@ public class EffMessage extends Effect {
 
 	@SuppressWarnings("null")
 	@Override
-	protected void execute(final Event e) {
-		for (Expression<String> message : messages) {
-			for (CommandSender sender : recipients.getArray(e)) {
-				if (message instanceof VariableString && sender instanceof Player) { // this could contain json formatting
-					List<MessageComponent> components = ((VariableString) message).getMessageComponents(e);
-					((Player) sender).spigot().sendMessage(BungeeConverter.convert(components.toArray(new MessageComponent[components.size()])));
-				} else {
-					String string = message.getSingle(e);
-					if (string != null)
-						sender.sendMessage(string);
-				}
+            protected void execute(final Event e) {
+                for (Expression<String> message : messages) {
+                    for (CommandSender sender : recipients.getArray(e)) {
+                        if (message instanceof VariableString && sender instanceof Player) { // this could contain json formatting
+                            List<MessageComponent> components = ((VariableString) message).getMessageComponents(e);
+                            ((Player) sender).spigot().sendMessage(BungeeConverter.convert(components.toArray(new MessageComponent[components.size()])));
+                        } else {
+                            String string = message.getSingle(e);
+                            if (string != null)
+                                sender.sendMessage(string);
+                        }
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -58,7 +58,13 @@ public class EffMessage extends Effect {
 
 	@Nullable
 	private Expression<String>[] messages;
-	
+
+	/**
+	 * Used for {@link EffMessage#toString(Event, boolean)}
+	 */
+	@Nullable
+	private Expression<String> messageExpr;
+
 	@SuppressWarnings("null")
 	private Expression<CommandSender> recipients;
 	
@@ -66,6 +72,7 @@ public class EffMessage extends Effect {
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
 		messages = (Expression<String>[]) (exprs[0] instanceof ExpressionList ? ((ExpressionList) exprs[0]).getExpressions() : new Expression[] {exprs[0]});
+		messageExpr = (Expression<String>) exprs[0];
 		recipients = (Expression<CommandSender>) exprs[1];
 		return true;
 	}
@@ -73,23 +80,23 @@ public class EffMessage extends Effect {
 	@SuppressWarnings("null")
 	@Override
 	protected void execute(final Event e) {
-		for (Expression<String> messageExpr : messages) {
+		for (Expression<String> message : messages) {
 			for (CommandSender sender : recipients.getArray(e)) {
-				if (messageExpr instanceof VariableString && sender instanceof Player) { // this could contain json formatting
-					List<MessageComponent> components = ((VariableString) messageExpr).getMessageComponents(e);
+				if (message instanceof VariableString && sender instanceof Player) { // this could contain json formatting
+					List<MessageComponent> components = ((VariableString) message).getMessageComponents(e);
 					((Player) sender).spigot().sendMessage(BungeeConverter.convert(components.toArray(new MessageComponent[components.size()])));
 				} else {
-					String message = messageExpr.getSingle(e);
-					if (message != null)
-						sender.sendMessage(message);
+					String string = message.getSingle(e);
+					if (string != null)
+						sender.sendMessage(string);
 				}
 			}
 		}
 	}
-	
+
+	@SuppressWarnings("null")
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
-		assert messages != null;
-		return "send " + "" + " to " + recipients.toString(e, debug);
+		return "send " + messageExpr.toString(e, debug) + " to " + recipients.toString(e, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -79,17 +79,17 @@ public class EffMessage extends Effect {
 
 	@SuppressWarnings("null")
 	@Override
-            protected void execute(final Event e) {
-                for (Expression<String> message : messages) {
-                    for (CommandSender sender : recipients.getArray(e)) {
-                        if (message instanceof VariableString && sender instanceof Player) { // this could contain json formatting
-                            List<MessageComponent> components = ((VariableString) message).getMessageComponents(e);
-                            ((Player) sender).spigot().sendMessage(BungeeConverter.convert(components.toArray(new MessageComponent[components.size()])));
-                        } else {
-                            String string = message.getSingle(e);
-                            if (string != null)
-                                sender.sendMessage(string);
-                        }
+	protected void execute(final Event e) {
+		for (Expression<String> message : messages) {
+			for (CommandSender sender : recipients.getArray(e)) {
+				if (message instanceof VariableString && sender instanceof Player) { // this could contain json formatting
+					List<MessageComponent> components = ((VariableString) message).getMessageComponents(e);
+					((Player) sender).spigot().sendMessage(BungeeConverter.convert(components.toArray(new MessageComponent[components.size()])));
+				} else {
+					String string = message.getSingle(e);
+					if (string != null)
+						sender.sendMessage(string);
+				}
 			}
 		}
 	}

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -19,16 +19,6 @@
  */
 package ch.njol.skript.effects;
 
-import java.lang.reflect.Array;
-import java.util.Arrays;
-import java.util.List;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.conversations.Conversable;
-import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
@@ -36,14 +26,18 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionList;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.BungeeConverter;
-import ch.njol.skript.util.chat.ChatMessages;
 import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.util.Kleenean;
-import net.md_5.bungee.api.chat.BaseComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.List;
 
 /**
  * @author Peter Güttinger
@@ -61,10 +55,9 @@ public class EffMessage extends Effect {
 	static {
 		Skript.registerEffect(EffMessage.class, "(message|send [message]) %strings% [to %commandsenders%]");
 	}
-	
+
 	@Nullable
-	private Expression<String> messages;
-	private boolean canSendRaw;
+	private Expression<String>[] messages;
 	
 	@SuppressWarnings("null")
 	private Expression<CommandSender> recipients;
@@ -72,33 +65,23 @@ public class EffMessage extends Effect {
 	@SuppressWarnings({"unchecked", "null"})
 	@Override
 	public boolean init(final Expression<?>[] exprs, final int matchedPattern, final Kleenean isDelayed, final ParseResult parser) {
-		messages = (Expression<String>) exprs[0];
-		canSendRaw = messages instanceof VariableString;
+		messages = (Expression<String>[]) (exprs[0] instanceof ExpressionList ? ((ExpressionList) exprs[0]).getExpressions() : new Expression[] {exprs[0]});
 		recipients = (Expression<CommandSender>) exprs[1];
 		return true;
 	}
-	
+
+	@SuppressWarnings("null")
 	@Override
 	protected void execute(final Event e) {
-		assert messages != null;
-		if (canSendRaw) {
-			assert messages != null;
-			List<MessageComponent> componentList = ((VariableString) messages).getMessageComponents(e);
-			@SuppressWarnings("null") // Most certainly safe, but I guess not...
-			BaseComponent[] components = BungeeConverter.convert(componentList.toArray(new MessageComponent[componentList.size()]));
-			for (final CommandSender s : recipients.getArray(e)) {
-				if (s instanceof Player) { // Use JSON chat
-					((Player) s).spigot().sendMessage(components);
-				} else { // Fall back to non-JSON chat
-					assert messages != null;
-					s.sendMessage(messages.getSingle(e));
-				}
-			}
-		} else {
-			assert messages != null;
-			for (final String message : messages.getArray(e)) {
-				for (final CommandSender s : recipients.getArray(e)) {
-					s.sendMessage(message);
+		for (Expression<String> messageExpr : messages) {
+			for (CommandSender sender : recipients.getArray(e)) {
+				if (messageExpr instanceof VariableString && sender instanceof Player) { // this could contain json formatting
+					List<MessageComponent> components = ((VariableString) messageExpr).getMessageComponents(e);
+					((Player) sender).spigot().sendMessage(BungeeConverter.convert(components.toArray(new MessageComponent[components.size()])));
+				} else {
+					String message = messageExpr.getSingle(e);
+					if (message != null)
+						sender.sendMessage(message);
 				}
 			}
 		}
@@ -107,6 +90,6 @@ public class EffMessage extends Effect {
 	@Override
 	public String toString(final @Nullable Event e, final boolean debug) {
 		assert messages != null;
-		return "send " + messages.toString(e, debug) + " to " + recipients.toString(e, debug);
+		return "send " + "" + " to " + recipients.toString(e, debug);
 	}
 }

--- a/src/main/java/ch/njol/skript/effects/EffMessage.java
+++ b/src/main/java/ch/njol/skript/effects/EffMessage.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
@@ -38,7 +39,6 @@ import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.util.chat.BungeeConverter;
 import ch.njol.skript.util.chat.MessageComponent;
 import ch.njol.util.Kleenean;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Peter Güttinger


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: Same as before (bungee chat api)
Related issues: #1153 

Description:
Tested cases:
![image](https://user-images.githubusercontent.com/28607612/37623612-5893b682-2b93-11e8-8e59-04c4ae7fcc1c.png)
![image](https://user-images.githubusercontent.com/28607612/37623652-7641575c-2b93-11e8-802e-da41d5cb4b84.png)
![image](https://user-images.githubusercontent.com/28607612/37623671-8644d16a-2b93-11e8-8d0e-d15a68063ec0.png)
![image](https://user-images.githubusercontent.com/28607612/37623836-07061548-2b94-11e8-8d32-ae7179ca8b3b.png)


![image](https://user-images.githubusercontent.com/28607612/37623747-bf11b026-2b93-11e8-84bc-43337233ce1e.png)
![image](https://user-images.githubusercontent.com/28607612/37623787-e43631ba-2b93-11e8-8e53-62a6b4c801a0.png)
![image](https://user-images.githubusercontent.com/28607612/37623713-a90bcb2c-2b93-11e8-8685-634f92ce090e.png)
![image](https://user-images.githubusercontent.com/28607612/37623845-11afc78c-2b94-11e8-9798-95405a97d2d7.png)
