### PR TITLE
add warning for String expression variablestrings

### DIFF
--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -19,6 +19,19 @@
  */
 package ch.njol.skript.lang;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
+import org.bukkit.ChatColor;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
@@ -43,18 +56,6 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
-import org.bukkit.ChatColor;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
 
 /**
  * Represents a string that may contain expressions, and is thus "variable".

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -306,7 +306,7 @@ public class VariableString implements Expression<String> {
 				((ExpressionInfo) string.get(0)).expr.getReturnType() == String.class &&
 				((ExpressionInfo) string.get(0)).expr.isSingle()) {
 			String expr = ((ExpressionInfo) string.get(0)).expr.toString(null, false);
-			Skript.warning(expr + " is already a text, so you should not put it in one (e.g. " + expr + " instead of " + "\"%" + expr + "%\")");
+			Skript.warning(expr + " is already a text, so you should not put it in one (e.g. " + expr + " instead of " + "\"%" + expr.replace("\"", "\"\"") + "%\")");
 		}
 		return new VariableString(orig, sa, mode);
 	}

--- a/src/main/java/ch/njol/skript/lang/VariableString.java
+++ b/src/main/java/ch/njol/skript/lang/VariableString.java
@@ -19,19 +19,6 @@
  */
 package ch.njol.skript.lang;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-
-import org.bukkit.ChatColor;
-import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptConfig;
@@ -42,7 +29,6 @@ import ch.njol.skript.config.Config;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.localization.Language;
-import ch.njol.skript.localization.Message;
 import ch.njol.skript.localization.Noun;
 import ch.njol.skript.log.BlockingLogHandler;
 import ch.njol.skript.log.RetainingLogHandler;
@@ -57,6 +43,18 @@ import ch.njol.util.Kleenean;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.SingleItemIterator;
+import org.bukkit.ChatColor;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 /**
  * Represents a string that may contain expressions, and is thus "variable".
@@ -303,6 +301,12 @@ public class VariableString implements Expression<String> {
 		
 		final Object[] sa = string.toArray();
 		assert sa != null;
+		if (string.size() == 1 && string.get(0) instanceof ExpressionInfo &&
+				((ExpressionInfo) string.get(0)).expr.getReturnType() == String.class &&
+				((ExpressionInfo) string.get(0)).expr.isSingle()) {
+			String expr = ((ExpressionInfo) string.get(0)).expr.toString(null, false);
+			Skript.warning(expr + " is already a text, so you should not put it in one (e.g. " + expr + " instead of " + "\"%" + expr + "%\")");
+		}
 		return new VariableString(orig, sa, mode);
 	}
 	


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: #1149

Description:
Makes this:
```
command test <string>:
  trigger:
    broadcast "%join """" with """"%"
```
warn saying this:
```
[17:50:27 WARN]: join "" with "" is already a text, so you should not put it in one (e.g. join "" with "" instead of "%join "" with ""%") (tests.sk, line 28: broadcast "%join """" with """"%"')
```
If anyone has suggestions for a better error message, please speak up because the current one sucks