### PR TITLE
Fix sticky function returns

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -19,6 +19,8 @@
  */
 package ch.njol.skript.lang.function;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.config.SectionNode;
@@ -28,8 +30,6 @@ import ch.njol.skript.lang.function.Functions.FunctionData;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.variables.Variables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.eclipse.jdt.annotation.Nullable;
-
 /**
  * @author Peter Güttinger
  */

--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -19,10 +19,7 @@
  */
 package ch.njol.skript.lang.function;
 
-import org.eclipse.jdt.annotation.Nullable;
-
 import ch.njol.skript.ScriptLoader;
-import ch.njol.skript.Skript;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.effects.EffReturn;
@@ -31,6 +28,7 @@ import ch.njol.skript.lang.function.Functions.FunctionData;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.variables.Variables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * @author Peter Güttinger
@@ -94,7 +92,9 @@ public class ScriptFunction<T> extends Function<T> {
 		assert trigger != null;
 		trigger.execute(e);
 		returnValueSet = false;
-		return returnValue;
+		T[] returnedValue = returnValue;
+		returnValue = null;
+		return returnedValue;
 	}
 	
 }


### PR DESCRIPTION
Target Minecraft versions: Any
Requirements: None
Related issues: There was one, but it's been closed and I can't find it

Description:
before:
```
function return(number: number) :: string:
  if {_number} is 1:
    return "uh oh sticky!"
on script load:
  broadcast return(1) # uh oh sticky!
  broadcast return(2) # uh oh sticky!
```
after:
```
function return(number: number) :: string:
  if {_number} is 1:
    return "uh oh sticky!"
on script load:
  broadcast return(1) # uh oh sticky!
  broadcast return(2) # nothing
```
