### PR TITLE
Fix returns in recursive functions

### DIFF
--- a/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
@@ -20,7 +20,6 @@
 package ch.njol.skript.lang.function;
 
 import org.bukkit.event.Event;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.Expression;

--- a/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
+++ b/src/main/java/ch/njol/skript/lang/function/ExprFunctionCall.java
@@ -20,6 +20,7 @@
 package ch.njol.skript.lang.function;
 
 import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 import ch.njol.skript.lang.Expression;
@@ -31,7 +32,7 @@ import ch.njol.util.Kleenean;
  * @author Peter Güttinger
  */
 public class ExprFunctionCall<T> extends SimpleExpression<T> {
-	
+
 	private final FunctionReference<T> function;
 	
 	public ExprFunctionCall(final FunctionReference<T> function) {
@@ -41,7 +42,9 @@ public class ExprFunctionCall<T> extends SimpleExpression<T> {
 	@Override
 	@Nullable
 	protected T[] get(final Event e) {
-		return function.execute(e);
+		T[] returnValue = function.execute(e);
+		function.resetReturnValue();
+		return returnValue;
 	}
 	
 	@Override

--- a/src/main/java/ch/njol/skript/lang/function/Function.java
+++ b/src/main/java/ch/njol/skript/lang/function/Function.java
@@ -129,7 +129,15 @@ public abstract class Function<T> {
 	 */
 	@Nullable
 	public abstract T[] execute(FunctionEvent<?> e, final Object[][] params);
-	
+
+	/**
+	 * Resets the return value of the {@code Function}.
+	 * Should be called right after execution.
+	 *
+	 * @return Whether or not the return value was successfully reset
+	 */
+	public abstract boolean resetReturnValue();
+
 	@Override
 	public String toString() {
 		return "function " + name;

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -169,7 +169,8 @@ public class FunctionReference<T> {
 		return true;
 	}
 
-	public @Nullable Function<? extends T> getFunction() {
+	@Nullable
+	public Function<? extends T> getFunction() {
 		return function;
 	}
 

--- a/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
+++ b/src/main/java/ch/njol/skript/lang/function/FunctionReference.java
@@ -168,7 +168,17 @@ public class FunctionReference<T> {
 		
 		return true;
 	}
-	
+
+	public @Nullable Function<? extends T> getFunction() {
+		return function;
+	}
+
+	public boolean resetReturnValue() {
+		if (function != null)
+			return function.resetReturnValue();
+		return false;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Nullable
 	protected T[] execute(final Event e) {

--- a/src/main/java/ch/njol/skript/lang/function/JavaFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/JavaFunction.java
@@ -93,5 +93,10 @@ public abstract class JavaFunction<T> extends Function<T> {
 	public String getSince() {
 		return since;
 	}
-	
+
+	@Override
+	public boolean resetReturnValue() {
+		return true;
+	}
+
 }

--- a/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
+++ b/src/main/java/ch/njol/skript/lang/function/ScriptFunction.java
@@ -91,10 +91,14 @@ public class ScriptFunction<T> extends Function<T> {
 		
 		assert trigger != null;
 		trigger.execute(e);
-		returnValueSet = false;
-		T[] returnedValue = returnValue;
-		returnValue = null;
-		return returnedValue;
+		return returnValue;
 	}
-	
+
+	@Override
+	public boolean resetReturnValue() {
+		returnValue = null;
+		returnValueSet = false;
+		return true;
+	}
+
 }


### PR DESCRIPTION
Target Minecraft versions: any
Requirements: None
Related issues: None

Description:
#1161 broke returns of recursive functions. This PR fixes sticky functions in a way that does not break recursive functions.
