### PR TITLE
Add tps expression

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprTPS.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTPS.java
@@ -43,9 +43,15 @@ import org.eclipse.jdt.annotation.Nullable;
 public class ExprTPS extends SimpleExpression<Double> {
 
 	private static final boolean SUPPORTED = Skript.methodExists(Server.class, "getTPS");
+	private int index;
+	private String expr;
 
 	static {
-		Skript.registerExpression(ExprTPS.class, Double.class, ExpressionType.SIMPLE, "[the] [server] tps");
+		Skript.registerExpression(ExprTPS.class, Double.class, ExpressionType.SIMPLE,
+				"tps from [the] last ([1] minute|1[ ]m[inute])",
+				"tps from [the] last 5[ ]m[inutes]",
+				"tps from [the] last 15[ ]m[inutes]",
+				"[the] tps");
 	}
 
 	@Override
@@ -54,12 +60,19 @@ public class ExprTPS extends SimpleExpression<Double> {
 			Skript.error("The TPS expression is not supported on this server software");
 			return false;
 		}
+		expr = parseResult.expr;
+		index = matchedPattern;
 		return true;
 	}
 
 	@Override
 	protected Double[] get(Event e) {
-		return CollectionUtils.wrap(Bukkit.getServer().getTPS());
+		double[] tps = Bukkit.getServer().getTPS();
+		if (index != 3) {
+			return new Double[] { tps[index] };
+		} else {
+			return CollectionUtils.wrap(tps);
+		}
 	}
 
 	@Override
@@ -69,12 +82,12 @@ public class ExprTPS extends SimpleExpression<Double> {
 
 	@Override
 	public boolean isSingle() {
-		return false;
+		return index != 3;
 	}
 
 	@Override
 	public String toString(@Nullable Event e, boolean debug) {
-		return "the tps";
+		return expr;
 	}
 
 }

--- a/src/main/java/ch/njol/skript/expressions/ExprTPS.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTPS.java
@@ -1,0 +1,71 @@
+/**
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * Copyright 2011-2017 Peter Güttinger and contributors
+ */
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+public class ExprTPS extends SimpleExpression<Double> {
+
+	private static final boolean SUPPORTED = Skript.methodExists(Server.class, "getTPS");
+
+	static {
+		Skript.registerExpression(ExprTPS.class, Double.class, ExpressionType.SIMPLE, "[the] [server] tps");
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		if (!SUPPORTED) {
+			Skript.error("The TPS expression is not supported on this server software");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	protected Double[] get(Event e) {
+		return CollectionUtils.wrap(Bukkit.getServer().getTPS());
+	}
+
+	@Override
+	public Class<? extends Double> getReturnType() {
+		return Double.class;
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "the tps";
+	}
+
+}

--- a/src/main/java/ch/njol/skript/expressions/ExprTPS.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTPS.java
@@ -44,7 +44,7 @@ public class ExprTPS extends SimpleExpression<Double> {
 
 	private static final boolean SUPPORTED = Skript.methodExists(Server.class, "getTPS");
 	private int index;
-	private String expr;
+	private String expr = "tps";
 
 	static {
 		Skript.registerExpression(ExprTPS.class, Double.class, ExpressionType.SIMPLE,

--- a/src/main/java/ch/njol/skript/expressions/ExprTPS.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprTPS.java
@@ -20,6 +20,10 @@
 package ch.njol.skript.expressions;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
@@ -31,6 +35,11 @@ import org.bukkit.Server;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
+@Name("TPS (ticks per second)")
+@Description("Returns the 3 most recent TPS readings, like the /tps command. " +
+			"This expression is only supported on some server software.")
+@Examples("broadcast \"%tps%\"")
+@Since("INSERT VERSION")
 public class ExprTPS extends SimpleExpression<Double> {
 
 	private static final boolean SUPPORTED = Skript.methodExists(Server.class, "getTPS");

--- a/src/main/java/ch/njol/util/coll/CollectionUtils.java
+++ b/src/main/java/ch/njol/util/coll/CollectionUtils.java
@@ -428,5 +428,13 @@ public abstract class CollectionUtils {
 			floats[i] = (float) doubles[i];
 		return floats;
 	}
+
+	public static Double[] wrap(double[] primitive) {
+		Double[] wrapped = new Double[primitive.length];
+		for (int i = 0; i < primitive.length; i++) {
+			wrapped[i] = primitive[i];
+		}
+		return wrapped;
+	}
 	
 }


### PR DESCRIPTION
Target Minecraft versions: Any (kinda)
Requirements: A recent version of Paper, the getTPS method relatively recently moved so this will only work on Paper versions released after that move.
Related issues: None

Description:
Adds a TPS expresssion that returns the last 3 tps numbers. If you can think of a way to support older Paper versions without reflection, i'll add it.