### PR TITLE
Feature suppress specific warns for specific skript

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
+	id 'com.github.johnrengelman.shadow' version '2.0.1'
     id "com.github.hierynomus.license" version "0.13.1"
 }
 
@@ -60,6 +61,9 @@ dependencies {
 	compile 'com.sk89q:worldguard:6.1.1-SNAPSHOT'
 	compile 'net.milkbowl.vault:Vault:1.6.6'
 	compile 'com.github.marcelo-mason:PreciousStones:24e3d4bf67b7240ae36b32be10e99d4091938c5c'
+	
+	compile 'me.nallar.whocalled:WhoCalled:1.1'
+	shadow 'me.nallar.whocalled:WhoCalled:1.1'
 
 	testCompile 'junit:junit:4.12'
 	testCompile 'org.easymock:easymock:3.4'
@@ -80,12 +84,23 @@ processResources {
 }
 
 jar {
-	archiveName System.getenv('SKRIPT_JAR_NAME') == null ? 'Skript.jar' : System.getenv("SKRIPT_JAR_NAME")
-	
+	enabled = false
+}
+
+assemble {
+	dependsOn shadowJar
+}
+
+shadowJar {
 	manifest {
 		attributes("Name": "ch/njol/skript",
 				"Sealed": "true")
 	}
+
+	baseName = System.getenv('SKRIPT_JAR_NAME') == null ? 'Skript' : System.getenv("SKRIPT_JAR_NAME")
+	classifier = null
+	version = null
+	configurations = [project.configurations.shadow]
 }
 
 license {

--- a/src/main/java/ch/njol/skript/SkriptAddon.java
+++ b/src/main/java/ch/njol/skript/SkriptAddon.java
@@ -35,6 +35,7 @@ import ch.njol.skript.localization.Language;
 import ch.njol.skript.util.Utils;
 import ch.njol.skript.util.Version;
 import ch.njol.util.coll.iterator.EnumerationIterable;
+import me.nallar.whocalled.WhoCalled;
 
 /**
  * Utility class for Skript addons. Use {@link Skript#registerAddon(JavaPlugin)} to create a SkriptAddon instance for your plugin.
@@ -53,6 +54,10 @@ public final class SkriptAddon {
 	 * @param p
 	 */
 	SkriptAddon(final JavaPlugin p) {
+		if (WhoCalled.$.getCallingClass() != Skript.class) {
+			throw new SkriptAPIException("use Skript#registerAddon(JavaPlugin), not the constructor");
+		}
+		
 		plugin = p;
 		name = "" + p.getName();
 		Version v;


### PR DESCRIPTION
Target Minecraft versions:*any
Requirements: none
Related issues: none

Proposed syntax:
`Suppress warns:
   variable.conflict
   variable.save`

Description:
It would be nice if it was possibility to supress warns in the skript where this suppress warns event is used in. Although warnings are usefull most of the times, sometimes they can get in the way of people. for example when they post their skript and it gives a bunch of variable conflict warns to the person who downloaded it while the variables aren't causing any probems. some people might not now how to disable the thing in the config. it isn't useful anymore due to how addons implemented the variable pattern for their types.